### PR TITLE
47 tweak layout and add missing info to pdf

### DIFF
--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -151,9 +151,10 @@ class PDF(FPDF):
         self.set_font('Times', size=10)
         self.cell(0, 10, f"Page: {self.page_no()}", align="C")
         self.set_x(10)
-        self.cell(0, 10, f"Printed: {self.date_printed.strftime(
+        timestamp = self.date_printed.strftime(
             '%Y-%m-%d %H:%M:%S %Z'
-        )}", align="L")
+        )
+        self.cell(0, 10, f"Exported: {timestamp}", align="L")
         self.set_x(10)
         self.set_y(-25)
         qr_img = self.generate_qr_code()

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -430,6 +430,7 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
                 ).astimezone().strftime('%Y-%m-%d'),
                 'tags': ', '.join(project['attributes']['tags'])
                 if project['attributes']['tags'] else 'NA',
+                'public': project['attributes']['public'],
                 'resource_type': 'NA',
                 'resource_lang': 'NA',
                 'funders': []

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -627,7 +627,7 @@ def write_pdf(projects, root_idx, folder=''):
                 markdown=True
             )
 
-    def write_project_body(pdf, project, parent_title=''):
+    def write_project_body(pdf, project, root_title='', root_url=''):
         """Write the body of a project to the PDF.
 
         Parameters
@@ -651,15 +651,18 @@ def write_pdf(projects, root_idx, folder=''):
         # Write header section
         title = project['metadata']['title']
         pdf.set_font('Times', size=18, style='B')
-        if parent_title:
-            pdf.multi_cell(0, h=0, text=f'{parent_title} /\n', align='L')
+        if root_title:
+            pdf.multi_cell(0, h=0, text=f'{root_title}\n', align='L')
+        if root_url:
+            pdf.multi_cell(0, h=0, text=f'Main Project URL: {root_url}\n', align='L')
         pdf.multi_cell(0, h=0, text=f'{title}\n', align='L')
         pdf.set_font('Times', size=12)
         url = project['metadata'].pop('url', '')
         if url:
+            label = 'Component URL' if root_title else 'Main Project URL'
             pdf.multi_cell(
                 0, h=0,
-                text=f'Project URL: {url}\n',
+                text=f'{label}: {url}\n',
                 align='L'
             )
             pdf.url = url
@@ -748,7 +751,7 @@ def write_pdf(projects, root_idx, folder=''):
 
         return pdf
 
-    def explore_project_tree(project, projects, pdf=None, parent_title=''):
+    def explore_project_tree(project, projects, pdf=None, parent_title='', parent_url=''):
         """Recursively find child projects and write them to the PDF.
 
         Parameters
@@ -770,9 +773,11 @@ def write_pdf(projects, root_idx, folder=''):
         # Start with no PDF at root projects
         if not pdf:
             pdf = PDF()
+            parent_title = project['metadata']['title']
+            parent_url = project['metadata']['url']
 
         # Add current project to PDF
-        pdf = write_project_body(pdf, project, parent_title=parent_title)
+        pdf = write_project_body(pdf, project, root_title=parent_title, root_url=parent_url)
 
         # Do children last so that come at end of the PDF
         children = project['children']
@@ -784,7 +789,7 @@ def write_pdf(projects, root_idx, folder=''):
                 # Pass current title to include in component header
                 parent_title = project['metadata']['title']
                 pdf = explore_project_tree(
-                    child_project, projects, pdf=pdf, parent_title=parent_title
+                    child_project, projects, pdf=pdf, parent_title=parent_title, parent_url=parent_url
                 )
 
         return pdf

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -670,7 +670,7 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_url:
             pdf.set_font('Times', size=12)
             pdf.cell(
-                text=f'Main Project URL: ', align='L'
+                text=f'Main Project URL:', align='L'
             )
             pdf.cell(
                 text=f'{pdf.parent_url}\n', align='L', link=pdf.parent_url
@@ -693,7 +693,7 @@ def write_pdf(projects, root_idx, folder=''):
         pdf.set_font('Times', size=12)
         if url and pdf.parent_url != url:
             pdf.cell(
-                text=f'Component URL: ',
+                text=f'Component URL:',
                 align='L'
             )
             pdf.cell(

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -718,14 +718,14 @@ def write_pdf(projects, root_idx, folder=''):
             row = table.row()
             row.cell('Name')
             row.cell('Bibliographic?')
-            row.cell('Email (if available)')
+            row.cell('Profile Link')
             for data_row in project['contributors']:
                 row = table.row()
                 for datum in data_row:
                     if datum is True:
                         datum = 'Yes'
                     if datum is False:
-                        datum = 'N/A'
+                        datum = 'No'
                     row.cell(datum)
         pdf.write(0, '\n')
         pdf.write(0, '\n')

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -671,10 +671,14 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_title != title:
             pdf.set_font('Times', size=18, style='B')
             pdf.multi_cell(0, h=0, text=f'{title}\n', align='L')
-        
+
         # Pop URL field to avoid printing it out in Metadata section
         url = project['metadata'].pop('url', '')
-        
+
+        pdf.url = url  # Set current URL to use in QR codes
+        qr_img = pdf.generate_qr_code()
+        pdf.image(qr_img, w=30, x=Align.R, y=5)
+
         pdf.set_font('Times', size=12)
         if url and pdf.parent_url != url:
             pdf.multi_cell(
@@ -682,10 +686,8 @@ def write_pdf(projects, root_idx, folder=''):
                 text=f'Component URL: {url}\n',
                 align='L'
             )
-        pdf.url = url  # Set current URL to use in QR codes
-        qr_img = pdf.generate_qr_code()
-        pdf.image(qr_img, w=30, x=Align.C)
 
+        pdf.ln()
         pdf.ln()
 
         # Write title for metadata section, then actual fields

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -511,10 +511,13 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
                     # Required data can either be embedded or in attributes
                     if 'embeds' in item and key != "subjects":
                         if 'users' in item['embeds']:
-                            values.append(
+                            values.append((
                                 item['embeds']['users']['data']
-                                ['attributes']['full_name']
-                            )
+                                ['attributes']['full_name'],
+                                item['attributes']['bibliographic'],
+                                item['embeds']['users']['data']
+                                ['links']['html']
+                            ))
                         else:
                             values.append(item['embeds']['attributes']['name'])
                     else:
@@ -531,11 +534,6 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
             if isinstance(values, list):
                 if key != 'contributors':
                     values = ', '.join(values)
-                else:
-                    contributors = []
-                    for c in values:
-                        contributors.append((c, False, 'N/A'))
-                    values = contributors
 
             if key in METADATA_RELATIONS:
                 project_data['metadata'][key] = values

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -416,13 +416,21 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
         else:
             added_node_ids.add(project['id'])
 
+        # Define nice representations of categories if needed
+        CATEGORY_STRS = {
+            '': 'Uncategorized',
+            'methods and measures': 'Methods and Measures'
+        }
+
         project_data = {
             'metadata': {
                 'title': project['attributes']['title'],
                 'id': project['id'],
                 'url': project['links']['html'],
                 'description': project['attributes']['description'],
-                'category': project['attributes']['category'],
+                'category': CATEGORY_STRS[project['attributes']['category']]
+                if project['attributes']['category'] in CATEGORY_STRS
+                else project['attributes']['category'].title(),
                 'date_created': datetime.datetime.fromisoformat(
                     project['attributes']['date_created']
                 ).astimezone().strftime('%Y-%m-%d'),

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -429,8 +429,8 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
                 'url': project['links']['html'],
                 'description': project['attributes']['description'],
                 'category': CATEGORY_STRS[project['attributes']['category']]
-                if project['attributes']['category'] in CATEGORY_STRS
-                else project['attributes']['category'].title(),
+                    if project['attributes']['category'] in CATEGORY_STRS
+                    else project['attributes']['category'].title(),
                 'date_created': datetime.datetime.fromisoformat(
                     project['attributes']['date_created']
                 ).astimezone().strftime('%Y-%m-%d'),
@@ -438,7 +438,7 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
                     project['attributes']['date_modified']
                 ).astimezone().strftime('%Y-%m-%d'),
                 'tags': ', '.join(project['attributes']['tags'])
-                if project['attributes']['tags'] else 'NA',
+                    if project['attributes']['tags'] else 'NA',
                 'public': project['attributes']['public'],
                 'resource_type': 'NA',
                 'resource_lang': 'NA',

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -422,6 +422,7 @@ def get_project_data(pat, dryrun=False, project_id='', usetest=False):
                 'id': project['id'],
                 'url': project['links']['html'],
                 'description': project['attributes']['description'],
+                'category': project['attributes']['category'],
                 'date_created': datetime.datetime.fromisoformat(
                     project['attributes']['date_created']
                 ).astimezone().strftime('%Y-%m-%d'),

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -669,10 +669,13 @@ def write_pdf(projects, root_idx, folder=''):
             pdf.multi_cell(0, h=0, text=f'{pdf.parent_title}\n', align='L')
         if pdf.parent_url:
             pdf.set_font('Times', size=12)
-            pdf.multi_cell(
-                0, h=0, text=f'Main Project URL: {pdf.parent_url}\n', align='L'
+            pdf.cell(
+                text=f'Main Project URL: ', align='L'
             )
-            pdf.write(0, '\n')
+            pdf.cell(
+                text=f'{pdf.parent_url}\n', align='L', link=pdf.parent_url
+            )
+            pdf.write(0, '\n\n')
 
         # Check if title, url is of parent's to avoid duplication
         title = project['metadata']['title']
@@ -689,11 +692,16 @@ def write_pdf(projects, root_idx, folder=''):
 
         pdf.set_font('Times', size=12)
         if url and pdf.parent_url != url:
-            pdf.multi_cell(
-                0, h=0,
-                text=f'Component URL: {url}\n',
+            pdf.cell(
+                text=f'Component URL: ',
                 align='L'
             )
+            pdf.cell(
+                text=f'{url}',
+                align='L',
+                link=url
+            )
+            pdf.write(0, '\n\n')
 
         pdf.ln()
         pdf.ln()
@@ -721,12 +729,16 @@ def write_pdf(projects, root_idx, folder=''):
             row.cell('Profile Link')
             for data_row in project['contributors']:
                 row = table.row()
-                for datum in data_row:
+                for idx, datum in enumerate(data_row):
                     if datum is True:
                         datum = 'Yes'
                     if datum is False:
                         datum = 'No'
-                    row.cell(datum)
+                    
+                    if idx == 2:
+                        row.cell(text=datum, link=datum)
+                    else:
+                        row.cell(datum)
         pdf.write(0, '\n')
         pdf.write(0, '\n')
 
@@ -749,12 +761,16 @@ def write_pdf(projects, root_idx, folder=''):
                 row.cell('Download Link')
                 for data_row in project['files']:
                     row = table.row()
-                    for datum in data_row:
+                    for idx, datum in enumerate(data_row):
                         if datum is True:
                             datum = 'Yes'
                         if datum is False or datum is None:
                             datum = 'N/A'
-                        row.cell(datum)
+                        
+                        if idx == 2:
+                            row.cell(text=datum, link=datum)
+                        else:
+                            row.cell(datum)
         else:
             pdf.write(0, '\n')
             pdf.multi_cell(

--- a/osfio-export-tool/src/exporter/stubs/contributorstubs.json
+++ b/osfio-export-tool/src/exporter/stubs/contributorstubs.json
@@ -1,44 +1,105 @@
 {
     "data": [
         {
-            "id": "x",
+            "id": "x-userid",
             "type": "contributors",
             "attributes": {
                 "index": 0,
-                "bibliographic": true,
+                "bibliographic": false,
                 "permission": "admin",
                 "unregistered_contributor": null,
                 "is_curator": false
             },
+            "relationships": {},
             "embeds": {
                 "users": {
                     "data": {
+                        "id": "userid",
+                        "type": "users",
                         "attributes": {
-                            "full_name": "Test User 1"
+                            "full_name": "Test User 1",
+                            "given_name": "",
+                            "middle_names": "",
+                            "family_name": "",
+                            "suffix": "",
+                            "date_registered": "",
+                            "active": true,
+                            "timezone": "Etc/UTC",
+                            "locale": "en_US",
+                            "social": {},
+                            "employment": [],
+                            "education": []
+                        },
+                        "relationships": {},
+                        "links": {
+                            "html": "https://test.osf.io/userid/",
+                            "profile_image": "https://secure.gravatar.com/avatar/id?d=identicon",
+                            "self": "https://api.test.osf.io/v2/users/userid/",
+                            "iri": "https://test.osf.io/userid"
                         }
                     }
                 }
+            },
+            "links": {
+                "html": "https://test.osf.io/userid/",
+                "profile_image": "https://secure.gravatar.com/avatar/id?d=identicon",
+                "self": "https://api.test.osf.io/v2/users/userid/",
+                "iri": "https://test.osf.io/userid"
             }
         },
         {
-            "id": "y",
+            "id": "x-userid2",
             "type": "contributors",
             "attributes": {
-                "index": 0,
+                "index": 1,
                 "bibliographic": true,
                 "permission": "admin",
                 "unregistered_contributor": null,
                 "is_curator": false
             },
+            "relationships": {},
             "embeds": {
                 "users": {
                     "data": {
+                        "id": "userid2",
+                        "type": "users",
                         "attributes": {
-                            "full_name": "Test User 2"
+                            "full_name": "Test User 2",
+                            "given_name": "",
+                            "middle_names": "",
+                            "family_name": "",
+                            "suffix": "",
+                            "date_registered": "",
+                            "active": true,
+                            "timezone": "Etc/UTC",
+                            "locale": "en_US"
+                        },
+                        "relationships": {},
+                        "links": {
+                            "html": "https://test.osf.io/userid2/",
+                            "profile_image": "https://secure.gravatar.com/avatar/id?d=identicon",
+                            "self": "https://api.test.osf.io/v2/users/userid2/",
+                            "iri": "https://test.osf.io/userid2"
                         }
                     }
                 }
+            },
+            "links": {
+                "self": "https://api.test.osf.io/v2/nodes/x/contributors/userid2/"
             }
         }
-    ]
+    ],
+    "meta": {
+        "total": 2,
+        "per_page": 10,
+        "total_bibliographic": 2,
+        "version": "2.20"
+    },
+    "links": {
+        "self": null,
+        "first": null,
+        "last": null,
+        "prev": null,
+        "next": null
+    }
 }

--- a/osfio-export-tool/src/exporter/stubs/nodestubs.json
+++ b/osfio-export-tool/src/exporter/stubs/nodestubs.json
@@ -327,7 +327,7 @@
             "attributes": {
                 "title": "Test2",
                 "description": "Test2 Description",
-                "category": "project",
+                "category": "",
                 "custom_citation": null,
                 "date_created": "2000-01-01T14:18:00.376705Z",
                 "date_modified": "2000-01-01T14:18:00.376705Z",

--- a/osfio-export-tool/src/exporter/stubs/nodestubs.json
+++ b/osfio-export-tool/src/exporter/stubs/nodestubs.json
@@ -6,7 +6,7 @@
             "attributes": {
                 "title": "Test1",
                 "description": "Test1 Description",
-                "category": "project",
+                "category": "methods and measures",
                 "custom_citation": null,
                 "date_created": "2000-01-01T14:18:00.376705Z",
                 "date_modified": "2000-01-01T14:18:00.376705Z",

--- a/osfio-export-tool/src/exporter/stubs/nodestubs.json
+++ b/osfio-export-tool/src/exporter/stubs/nodestubs.json
@@ -30,7 +30,7 @@
                 "current_user_is_contributor": true,
                 "current_user_is_contributor_or_group_member": true,
                 "wiki_enabled": true,
-                "public": false
+                "public": true
             },
             "relationships": {
                 "license": {

--- a/osfio-export-tool/src/exporter/stubs/nodestubs.json
+++ b/osfio-export-tool/src/exporter/stubs/nodestubs.json
@@ -64,7 +64,7 @@
                 "contributors": {
                     "links": {
                         "related": {
-                            "href": "https://api.test.osf.io/v2/nodes/x/contributors/",
+                            "href": "contributors",
                             "meta": {}
                         }
                     }
@@ -372,7 +372,7 @@
                 "contributors": {
                     "links": {
                         "related": {
-                            "href": "https://api.test.osf.io/v2/nodes/x/contributors/",
+                            "href": "contributors",
                             "meta": {}
                         }
                     }
@@ -680,7 +680,7 @@
                 "contributors": {
                     "links": {
                         "related": {
-                            "href": "https://api.test.osf.io/v2/nodes/x/contributors/",
+                            "href": "contributors",
                             "meta": {}
                         }
                     }
@@ -997,7 +997,7 @@
                 "contributors": {
                     "links": {
                         "related": {
-                            "href": "https://api.test.osf.io/v2/nodes/x/contributors/",
+                            "href": "contributors/",
                             "meta": {}
                         }
                     }
@@ -1327,7 +1327,7 @@
                 "contributors": {
                     "links": {
                         "related": {
-                            "href": "https://api.test.osf.io/v2/nodes/x/contributors/",
+                            "href": "contributors/",
                             "meta": {}
                         }
                     }

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -314,6 +314,9 @@ class TestClient(TestCase):
         assert projects[0]['metadata']['public']
         assert not projects[1]['metadata']['public']
 
+        assert projects[0]['metadata']['category'] == 'project'
+        assert projects[1]['metadata']['category'] == ''
+
     def test_get_single_mock_project(self):
         projects, roots = get_project_data(
             os.getenv('TEST_PAT', ''), dryrun=True,

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -255,18 +255,32 @@ class TestClient(TestCase):
             'Expected tags NA, got: ',
             projects[1]['metadata']['tags']
         )
-        assert projects[0]['contributors'][0] == (
-            'Test User 1', False, 'N/A'
-        ), (
-            "Expected contributor ('Test User 1', False, 'N/A'), got: ",
-            projects[0]['contributors'][0]
+
+        assert projects[0]['contributors'][0][0] == 'Test User 1', (
+            "Expected contributor Test User 1, got: ",
+            projects[0]['contributors'][0][0]
         )
-        assert projects[0]['contributors'][1] == (
-            'Test User 2', False, 'N/A'
-        ), (
-            "Expected contributor ('Test User 2', False, 'N/A'), got: ",
-            projects[0]['contributors'][1]
+        assert projects[0]['contributors'][0][1] == False, (
+            "Expected contributor status False, got: ",
+            projects[0]['contributors'][0][1]
         )
+        assert projects[0]['contributors'][0][2] == 'https://test.osf.io/userid/', (
+            "Expected contributor link https://test.osf.io/userid/, got: ",
+            projects[0]['contributors'][0][2]
+        )
+        assert projects[0]['contributors'][1][0] == 'Test User 2', (
+            "Expected contributor Test User 2, got: ",
+            projects[0]['contributors'][1][0]
+        )
+        assert projects[0]['contributors'][1][1] == True, (
+            "Expected contributor status True, got: ",
+            projects[0]['contributors'][1][1]
+        )
+        assert projects[0]['contributors'][1][2] == 'https://test.osf.io/userid2/', (
+            "Expected contributor link https://test.osf.io/userid2/, got: ",
+            projects[0]['contributors'][1][2]
+        )
+        
         doi = projects[0]['metadata']['identifiers']
         assert doi == '10.4-2-6-25/OSF.IO/74PAD', (
             'Expected identifiers 10.4-2-6-25/OSF.IO/74PAD, got: ',

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -369,6 +369,7 @@ class TestClient(TestCase):
                 'metadata': {
                     "title": "child1",
                     "id": "a",
+                    'url': 'hdssdadsadsads'
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),
@@ -470,6 +471,7 @@ class TestClient(TestCase):
 
         # Get URL now as it will be removed later
         url = projects[0]['metadata']['url']
+        url_comp = projects[1]['metadata']['url']
 
         # Do we write only one PDF per project?
         # pdb.set_trace()
@@ -511,13 +513,21 @@ class TestClient(TestCase):
         content_fourth_page = import_one.pages[3].extract_text(
             extraction_mode='layout'
         )
-        assert 'My Project Title /\nchild1' in content_third_page
-        assert 'child1 /\nchild2' in content_fourth_page
-        assert 'Title: child1' in content_third_page
-        assert 'Title: child2' in content_fourth_page
+        assert f'{projects[0]['metadata']['title']}' in content_third_page, (
+            content_third_page
+        )
+        assert f'Main Project URL: {url}' in content_third_page, (
+            content_third_page
+        )
+        assert f'{projects[1]['metadata']['title']}' in content_third_page
+        assert f'Component URL: {url_comp}' in content_third_page
 
-        assert f'Project URL: {url}' in content_first_page
-        assert 'Project URL:' not in content_second_page
+        assert f'Main Project URL: {url}' in content_first_page, (
+            content_third_page
+        )
+        assert f'Main Project URL: {url}' not in content_second_page, (
+            content_third_page
+        )
 
         timestamp = pdf_one.date_printed.strftime(
             '%Y-%m-%d %H:%M:%S %Z')

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -332,7 +332,7 @@ class TestClient(TestCase):
                 'metadata': {
                     'title': 'My Project Title',
                     'id': 'id',
-                    'url': 'https://test.osf.io/',
+                    'url': 'https://test.osf.io/x',
                     'description': 'This is a description of the project',
                     'date_created': datetime.datetime.fromisoformat(
                         '2025-06-12T15:54:42.105112Z'
@@ -369,7 +369,7 @@ class TestClient(TestCase):
                 'metadata': {
                     "title": "child1",
                     "id": "a",
-                    'url': 'hdssdadsadsads'
+                    'url': 'https://test.osf.io/a'
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -260,27 +260,29 @@ class TestClient(TestCase):
             "Expected contributor Test User 1, got: ",
             projects[0]['contributors'][0][0]
         )
-        assert projects[0]['contributors'][0][1] == False, (
+        assert not projects[0]['contributors'][0][1], (
             "Expected contributor status False, got: ",
             projects[0]['contributors'][0][1]
         )
-        assert projects[0]['contributors'][0][2] == 'https://test.osf.io/userid/', (
-            "Expected contributor link https://test.osf.io/userid/, got: ",
+        link = 'https://test.osf.io/userid/'
+        link_two = 'https://test.osf.io/userid2/'
+        assert projects[0]['contributors'][0][2] == link, (
+            f"Expected contributor link {link}, got: ",
             projects[0]['contributors'][0][2]
         )
         assert projects[0]['contributors'][1][0] == 'Test User 2', (
             "Expected contributor Test User 2, got: ",
             projects[0]['contributors'][1][0]
         )
-        assert projects[0]['contributors'][1][1] == True, (
+        assert projects[0]['contributors'][1][1], (
             "Expected contributor status True, got: ",
             projects[0]['contributors'][1][1]
         )
-        assert projects[0]['contributors'][1][2] == 'https://test.osf.io/userid2/', (
-            "Expected contributor link https://test.osf.io/userid2/, got: ",
+        assert projects[0]['contributors'][1][2] == link_two, (
+            f"Expected contributor link {link_two}, got: ",
             projects[0]['contributors'][1][2]
         )
-        
+
         doi = projects[0]['metadata']['identifiers']
         assert doi == '10.4-2-6-25/OSF.IO/74PAD', (
             'Expected identifiers 10.4-2-6-25/OSF.IO/74PAD, got: ',
@@ -379,7 +381,7 @@ class TestClient(TestCase):
                     ('Margarine', True, 'https://test.osf.io/userid/')
                 ],
                 'files': [
-                    ('file1.txt', None, None),
+                    ('file1.txt', None, 'https://test.osf.io/userid/'),
                     ('file2.txt', None, None),
                 ],
                 'funders': [],
@@ -398,7 +400,8 @@ class TestClient(TestCase):
                 },
                 'contributors': [
                     (
-                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
+                        'Long Double-Barrelled Name and Surname',
+                        False, 'https://test.osf.io/userid/'
                     ),
                     (
                         'name2', True, 'https://test.osf.io/userid/'
@@ -424,7 +427,8 @@ class TestClient(TestCase):
                 },
                 'contributors': [
                     (
-                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
+                        'Long Double-Barrelled Name and Surname',
+                        False, 'https://test.osf.io/userid/'
                     ),
                     (
                         'name2', True, 'https://test.osf.io/userid/'
@@ -449,7 +453,8 @@ class TestClient(TestCase):
                 },
                 'contributors': [
                     (
-                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
+                        'Long Double-Barrelled Name and Surname',
+                        False, 'https://test.osf.io/userid/'
                     ),
                     (
                         'name2', True, 'https://test.osf.io/userid/'
@@ -547,16 +552,16 @@ class TestClient(TestCase):
             'Subjects: sub1, sub2, sub3\n\n'
             '2. Contributors\n\n'
             'Name                                               '
-            'Bibliographic?           '
+            'Bibliographic?            '
             'Profile Link\n\n'
             'Pineapple Pizza                                    '
-            'No                       '
+            'No                        '
             'https://test.osf.io/userid/\n\n'
             'Margarita                                          '
-            'Yes                      '
+            'Yes                       '
             'https://test.osf.io/userid/\n\n'
             'Margarine                                          '
-            'Yes                      '
+            'Yes                       '
             'https://test.osf.io/userid/\n\n'
             '3. Files in Main Project'
         )
@@ -568,13 +573,13 @@ class TestClient(TestCase):
             '3. Files in Main Project\n\n'
             'OSF Storage\n\n'
             'File Name                                          '
-            'Size (MB)                '
+            'Size (MB)                 '
             'Download Link\n\n'
             'file1.txt                                          '
-            'N/A                      '
-            'N/A\n\n'
+            'N/A                       '
+            'https://test.osf.io/userid/\n\n'
             'file2.txt                                          '
-            'N/A                      '
+            'N/A                       '
             'N/A\n\n'
             '4. Wiki'
         )

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -402,7 +402,8 @@ class TestClient(TestCase):
             {
                 'metadata': {
                     "title": "Second Project in new PDF",
-                    "id": "c"
+                    "id": "c",
+                    'url': 'lol'
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),
@@ -436,6 +437,7 @@ class TestClient(TestCase):
                 'metadata': {
                     "title": "child2",
                     "id": "b",
+                    'url': 'dan'
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -512,9 +512,6 @@ class TestClient(TestCase):
         content_third_page = import_one.pages[2].extract_text(
             extraction_mode='layout'
         )
-        content_fourth_page = import_one.pages[3].extract_text(
-            extraction_mode='layout'
-        )
         assert f'{projects[0]['metadata']['title']}' in content_third_page, (
             content_third_page
         )
@@ -616,7 +613,7 @@ class TestClient(TestCase):
         project_id = extract_project_id(url)
         assert project_id == 'x', f'Expected "x", got {project_id}'
 
-        # TODO: add test for passing a URL for test site when 
+        # TODO: add test for passing a URL for test site when
         # we are using production site, and vice versa
 
         url = 'x'

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -314,8 +314,12 @@ class TestClient(TestCase):
         assert projects[0]['metadata']['public']
         assert not projects[1]['metadata']['public']
 
-        assert projects[0]['metadata']['category'] == 'project'
-        assert projects[1]['metadata']['category'] == ''
+        assert projects[0]['metadata']['category'] == 'Methods and Measures', (
+            projects[0]['metadata']['category']
+        )
+        assert projects[1]['metadata']['category'] == 'Uncategorized', (
+            projects[1]['metadata']['category']
+        )
 
     def test_get_single_mock_project(self):
         projects, roots = get_project_data(
@@ -339,6 +343,7 @@ class TestClient(TestCase):
                     'title': 'My Project Title',
                     'id': 'id',
                     'url': 'https://test.osf.io/x',
+                    'category': 'Uncategorized',
                     'description': 'This is a description of the project',
                     'date_created': datetime.datetime.fromisoformat(
                         '2025-06-12T15:54:42.105112Z'
@@ -375,7 +380,7 @@ class TestClient(TestCase):
                 'metadata': {
                     "title": "child1",
                     "id": "a",
-                    'url': 'https://test.osf.io/a'
+                    'url': 'https://test.osf.io/a',
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),
@@ -409,7 +414,8 @@ class TestClient(TestCase):
                 'metadata': {
                     "title": "Second Project in new PDF",
                     "id": "c",
-                    'url': 'lol'
+                    'url': 'lol',
+                    'category': 'Methods and Measures'
                 },
                 'contributors': [
                     ('Short Name', True, 'email'),
@@ -532,6 +538,13 @@ class TestClient(TestCase):
         )
         assert f'Main Project URL: {url}' not in content_second_page, (
             content_third_page
+        )
+
+        assert 'Category: Uncategorized' in content_first_page, (
+            content_first_page
+        )
+        assert 'Category: Methods and Measures' in content_second_page, (
+            content_second_page
         )
 
         timestamp = pdf_one.date_printed.strftime(

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -374,9 +374,9 @@ class TestClient(TestCase):
                     'subjects': 'sub1, sub2, sub3',
                 },
                 'contributors': [
-                    ('Pineapple Pizza', True, 'email'),
-                    ('Margarita', True, 'email'),
-                    ('Margarine', True, 'email')
+                    ('Pineapple Pizza', False, 'https://test.osf.io/userid/'),
+                    ('Margarita', True, 'https://test.osf.io/userid/'),
+                    ('Margarine', True, 'https://test.osf.io/userid/')
                 ],
                 'files': [
                     ('file1.txt', None, None),
@@ -397,23 +397,14 @@ class TestClient(TestCase):
                     'url': 'https://test.osf.io/a',
                 },
                 'contributors': [
-                    ('Short Name', True, 'email'),
                     (
-                        'Long Double-Barrelled Name and Surname', True,
-                        (
-                            'Long Double-Barrelled Name and Surname@'
-                            'Long Double-Barrelled Name and Surname.com'
-                        )
+                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
                     ),
                     (
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            'Long Double-Barrelled Name and Surname'
-                        ), True,
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            '@Long Double-Barrelled Name and Surname.com'
-                        )
+                        'name2', True, 'https://test.osf.io/userid/'
+                    ),
+                    (
+                        'name3', True, 'https://test.osf.io/userid/'
                     )
                 ],
                 'files': [
@@ -432,23 +423,14 @@ class TestClient(TestCase):
                     'category': 'Methods and Measures'
                 },
                 'contributors': [
-                    ('Short Name', True, 'email'),
                     (
-                        'Long Double-Barrelled Name and Surname', True,
-                        (
-                            'Long Double-Barrelled Name and Surname@'
-                            'Long Double-Barrelled Name and Surname.com'
-                        )
+                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
                     ),
                     (
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            'Long Double-Barrelled Name and Surname'
-                        ), True,
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            '@Long Double-Barrelled Name and Surname.com'
-                        )
+                        'name2', True, 'https://test.osf.io/userid/'
+                    ),
+                    (
+                        'name3', True, 'https://test.osf.io/userid/'
                     )
                 ],
                 'files': [
@@ -466,23 +448,14 @@ class TestClient(TestCase):
                     'url': 'dan'
                 },
                 'contributors': [
-                    ('Short Name', True, 'email'),
                     (
-                        'Long Double-Barrelled Name and Surname', True,
-                        (
-                            'Long Double-Barrelled Name and Surname@'
-                            'Long Double-Barrelled Name and Surname.com'
-                        )
+                        'Long Double-Barrelled Name and Surname', False, 'https://test.osf.io/userid/'
                     ),
                     (
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            'Long Double-Barrelled Name and Surname'
-                        ), True,
-                        (
-                            'Long Double-Barrelled Name and Surname'
-                            '@Long Double-Barrelled Name and Surname.com'
-                        )
+                        'name2', True, 'https://test.osf.io/userid/'
+                    ),
+                    (
+                        'name3', True, 'https://test.osf.io/userid/'
                     )
                 ],
                 'files': [
@@ -573,44 +546,39 @@ class TestClient(TestCase):
         contributors_table = (
             'Subjects: sub1, sub2, sub3\n\n'
             '2. Contributors\n\n'
-            'Name                                              '
+            'Name                                               '
             'Bibliographic?           '
-            'Email (if available)\n\n'
-            'Pineapple Pizza                                   '
+            'Profile Link\n\n'
+            'Pineapple Pizza                                    '
+            'No                       '
+            'https://test.osf.io/userid/\n\n'
+            'Margarita                                          '
             'Yes                      '
-            'email\n\n'
-            'Margarine                                         '
+            'https://test.osf.io/userid/\n\n'
+            'Margarine                                          '
             'Yes                      '
-            'email\n\n'
+            'https://test.osf.io/userid/\n\n'
             '3. Files in Main Project'
-        ).join('')
-
-        assert contributors_table in content_first_page, (
-            contributors_table,
-            content_first_page
         )
+        assert contributors_table in content_first_page
 
         # This way of string formatting compresses line lengths used
         # End of headers and table rows marked by \n\n
         files_table = (
             '3. Files in Main Project\n\n'
             'OSF Storage\n\n'
-            'File Name                                         '
+            'File Name                                          '
             'Size (MB)                '
             'Download Link\n\n'
-            'file1.txt                                         '
+            'file1.txt                                          '
             'N/A                      '
             'N/A\n\n'
-            'file2.txt                                         '
+            'file2.txt                                          '
             'N/A                      '
             'N/A\n\n'
             '4. Wiki'
-        ).join('')
-
-        assert files_table in content_first_page, (
-            files_table,
-            content_first_page
         )
+        assert files_table in content_first_page
 
     def test_pull_projects_command_on_mocks(self):
         """Test generating a PDF from parsed project data.

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -311,6 +311,9 @@ class TestClient(TestCase):
         assert 'a' in projects[0]['children']
         assert 'b' in projects[0]['children']
 
+        assert projects[0]['metadata']['public']
+        assert not projects[1]['metadata']['public']
+
     def test_get_single_mock_project(self):
         projects, roots = get_project_data(
             os.getenv('TEST_PAT', ''), dryrun=True,

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -597,16 +597,13 @@ class TestClient(TestCase):
         assert f'{projects[0]['metadata']['title']}' in content_third_page, (
             content_third_page
         )
-        assert f'Main Project URL: {url}' in content_third_page, (
+        assert f'{url}' in content_third_page, (
             content_third_page
         )
         assert f'{projects[1]['metadata']['title']}' in content_third_page
-        assert f'Component URL: {url_comp}' in content_third_page
+        assert f'{url_comp}' in content_third_page
 
-        assert f'Main Project URL: {url}' in content_first_page, (
-            content_third_page
-        )
-        assert f'Main Project URL: {url}' not in content_second_page, (
+        assert f'{url}' in content_first_page, (
             content_third_page
         )
 
@@ -662,10 +659,6 @@ class TestClient(TestCase):
             '4. Wiki'
         )
         assert files_table in content_first_page
-
-        # Remove files only if all good - keep for debugging otherwise
-        os.remove(path_one)
-        os.remove(path_two)
 
         # Remove files only if all good - keep for debugging otherwise
         os.remove(path_one)

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -488,27 +488,27 @@ class TestClient(TestCase):
         files = os.listdir(FOLDER_OUT)
         assert len(files) == 2
 
-        pdf_first = PdfReader(os.path.join(
+        import_one = PdfReader(os.path.join(
             FOLDER_OUT, "My Project Title_export.pdf"
         ))
-        pdf_second = PdfReader(os.path.join(
+        import_two = PdfReader(os.path.join(
             FOLDER_OUT, "Second Project in new PDF_export.pdf"
         ))
-        assert len(pdf_first.pages) == 4, (
+        assert len(import_one.pages) == 4, (
             'Expected 4 pages in the first PDF, got: ',
-            len(pdf_first.pages)
+            len(import_one.pages)
         )
 
-        content_first_page = pdf_first.pages[0].extract_text(
+        content_first_page = import_one.pages[0].extract_text(
             extraction_mode='layout'
         )
-        content_second_page = pdf_second.pages[0].extract_text(
+        content_second_page = import_two.pages[0].extract_text(
             extraction_mode='layout'
         )
-        content_third_page = pdf_first.pages[2].extract_text(
+        content_third_page = import_one.pages[2].extract_text(
             extraction_mode='layout'
         )
-        content_fourth_page = pdf_first.pages[3].extract_text(
+        content_fourth_page = import_one.pages[3].extract_text(
             extraction_mode='layout'
         )
         assert 'My Project Title /\nchild1' in content_third_page
@@ -518,6 +518,13 @@ class TestClient(TestCase):
 
         assert f'Project URL: {url}' in content_first_page
         assert 'Project URL:' not in content_second_page
+
+        timestamp = pdf_one.date_printed.strftime(
+            '%Y-%m-%d %H:%M:%S %Z')
+        assert f'Exported: {timestamp}' in content_first_page, (
+            'Actual content:',
+            content_first_page
+        )
 
         # This way of string formatting compresses line lengths used
         # End of headers and table rows marked by \n\n


### PR DESCRIPTION
Closes #47

- Reformat timestamp in PDF to Exported: <time>
- Add field for if project is public/private
- Add category field
- Reformat project titles, component titles and project URLs
- Add bibliographic status and profile links for contributors
- Make project URLs and links in tables interactable