### PR TITLE
fix: Correct bad import for os.path.exists in test_write_pdf_without_giving_a_folder

### DIFF
--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -376,7 +376,7 @@ class TestClient(TestCase):
         except Exception as e:
             print(e)
         finally:
-            if os.exists(path_one):
+            if os.path.exists(path_one):
                 os.remove(path_one)
         
         assert is_filename_match, (


### PR DESCRIPTION
Hotfix for a broken test.