### PR TITLE
19 add permission checks for exporting projects

### DIFF
--- a/osfio-export-tool/src/client/__init__.py
+++ b/osfio-export-tool/src/client/__init__.py
@@ -1,8 +1,9 @@
 from .cli import (
-    cli, extract_project_id
+    cli, extract_project_id, prompt_pat
 )
 
 __all__ = [
     'cli',
-    'extract_project_id'
+    'extract_project_id',
+    prompt_pat
 ]

--- a/osfio-export-tool/src/client/cli.py
+++ b/osfio-export-tool/src/client/cli.py
@@ -26,12 +26,30 @@ def extract_project_id(url):
     project_id = url.strip("/").split("/")[-1]
     return project_id
 
+
 def prompt_pat(project_id='', usetest=False):
+    """
+    Ask for a PAT if exporting a single project or all projects a user has.
+
+    Parameters
+    -------------
+        project_id: str
+            ID of a single project to export.
+            If one provided then ask for a PAT.
+        usetest: bool
+            Flag to indicate whether to use the test/production API server.
+
+    Returns
+    -----------------
+        pat: str
+            Personal Access Token to use to authorise a user.
+    """
+
     if usetest:
         api_host = API_HOST_TEST
     else:
         api_host = API_HOST_PROD
-    
+
     if not project_id:
         pat = click.prompt(
             'Please enter your PAT to export all your projects',
@@ -46,7 +64,7 @@ def prompt_pat(project_id='', usetest=False):
         )
     else:
         pat = ''
-    
+
     return pat
 
 
@@ -79,7 +97,7 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
         click.echo(f'Extracting project with ID: {project_id}')
     else:
         click.echo('No project ID provided, extracting all projects.')
-    
+
     if not pat:
         pat = prompt_pat(project_id=project_id, usetest=usetest)
 

--- a/osfio-export-tool/src/client/cli.py
+++ b/osfio-export-tool/src/client/cli.py
@@ -26,6 +26,23 @@ def extract_project_id(url):
     project_id = url.strip("/").split("/")[-1]
     return project_id
 
+def prompt_pat(project_id, usetest=False):
+    pat = ''
+
+    if usetest:
+        api_host = API_HOST_TEST
+    else:
+        api_host = API_HOST_PROD
+    
+    if not exporter.is_public(f'{api_host}/nodes/{project_id}/'):
+        pat = click.prompt(
+            'Please enter your PAT to access this private project: ',
+            type=str,
+            hide_input=True
+        )
+    
+    return pat
+
 
 @click.command()
 @click.option('--pat', type=str, default='',

--- a/osfio-export-tool/src/exporter/__init__.py
+++ b/osfio-export-tool/src/exporter/__init__.py
@@ -1,7 +1,7 @@
 from .exporter import (
     call_api, get_project_data,
     explore_file_tree, explore_wikis,
-    write_pdf
+    write_pdf, is_public
 )
 
 __all__ = [
@@ -9,5 +9,6 @@ __all__ = [
     'get_project_data',
     'explore_file_tree',
     'explore_wikis',
-    'write_pdf'
+    'write_pdf',
+    'is_public'
 ]

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -37,6 +37,15 @@ def get_host(is_test):
 
     return API_HOST_TEST if is_test else API_HOST_PROD
 
+def is_public(url):
+    request = webhelper.Request(url, method='GET')
+    try:
+        result = webhelper.urlopen(request).status
+    except webhelper.HTTPError as e:
+        result = e
+    
+    return result == 200
+
 
 class MockAPIResponse:
     """Simulate OSF API response for testing purposes."""

--- a/osfio-export-tool/src/exporter/exporter.py
+++ b/osfio-export-tool/src/exporter/exporter.py
@@ -37,13 +37,21 @@ def get_host(is_test):
 
     return API_HOST_TEST if is_test else API_HOST_PROD
 
+
 def is_public(url):
+    """Return boolean to indicate if a URL is public (True) or not (False).
+
+    Parameters
+    ------------
+    url: str
+        The URL to test.
+    """
+
     request = webhelper.Request(url, method='GET')
     try:
         result = webhelper.urlopen(request).status
     except webhelper.HTTPError as e:
         result = e
-    
     return result == 200
 
 
@@ -679,7 +687,7 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_url:
             pdf.set_font('Times', size=12)
             pdf.cell(
-                text=f'Main Project URL:', align='L'
+                text='Main Project URL:', align='L'
             )
             pdf.cell(
                 text=f'{pdf.parent_url}\n', align='L', link=pdf.parent_url
@@ -702,7 +710,7 @@ def write_pdf(projects, root_idx, folder=''):
         pdf.set_font('Times', size=12)
         if url and pdf.parent_url != url:
             pdf.cell(
-                text=f'Component URL:',
+                text='Component URL:',
                 align='L'
             )
             pdf.cell(
@@ -743,7 +751,6 @@ def write_pdf(projects, root_idx, folder=''):
                         datum = 'Yes'
                     if datum is False:
                         datum = 'No'
-                    
                     if idx == 2:
                         row.cell(text=datum, link=datum)
                     else:
@@ -775,7 +782,6 @@ def write_pdf(projects, root_idx, folder=''):
                             datum = 'Yes'
                         if datum is False or datum is None:
                             datum = 'N/A'
-                        
                         if idx == 2:
                             row.cell(text=datum, link=datum)
                         else:

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -1,5 +1,6 @@
 import datetime
 from unittest import TestCase
+from urllib.request import HTTPError
 import os
 import shutil
 import json
@@ -7,6 +8,7 @@ import pdb  # Use pdb.set_trace() to help with debugging
 import traceback
 import random
 import string
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from pypdf import PdfReader
@@ -20,7 +22,7 @@ from exporter import (
     is_public
 )
 from client import (
-    cli, extract_project_id
+    cli, extract_project_id, prompt_pat
 )
 
 TEST_PDF_FOLDER = 'good-pdfs'
@@ -144,6 +146,7 @@ class TestAPI(TestCase):
     def test_get_public_status_on_code(self):
         assert not is_public(f'{TestAPI.API_HOST}/users/me')
         assert is_public(f'{TestAPI.API_HOST}')
+        
 
 
 class TestClient(TestCase):
@@ -757,3 +760,13 @@ class TestClient(TestCase):
         finally:
             if os.path.exists(folder):
                 shutil.rmtree(folder)
+    
+    @patch('exporter.is_public', lambda x: False)
+    def test_prompt_pat_if_private(self):
+        pat = prompt_pat('x')
+        assert pat != ''
+    
+    @patch('exporter.is_public', lambda x: True)
+    def test_prompt_pat_if_public(self):
+        pat = prompt_pat('x')
+        assert pat == ''

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -54,6 +54,19 @@ class TestAPI(TestCase):
             'Expected API version 2.20, actual version: ',
             data['meta']['version']
         )
+    
+    def test_call_api_no_pat(self):
+        public_node_id = json.loads(
+            call_api(
+                f'{TestAPI.API_HOST}/nodes', pat='',
+                per_page=1
+            ).read()
+        )['data'][0]['id']
+
+        result = call_api(
+            f'{TestAPI.API_HOST}/nodes/{public_node_id}/', pat='',
+        )
+        assert result.status == 200
 
     def test_parse_single_project_json_as_expected(self):
         # Use first public project available for this test

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -16,7 +16,8 @@ from exporter import (
     get_project_data,
     explore_file_tree,
     explore_wikis,
-    write_pdf
+    write_pdf,
+    is_public
 )
 from client import (
     cli, extract_project_id
@@ -139,6 +140,10 @@ class TestAPI(TestCase):
             result.exc_info,
             traceback.format_tb(result.exc_info[2])
         )
+    
+    def test_get_public_status_on_code(self):
+        assert not is_public(f'{TestAPI.API_HOST}/users/me')
+        assert is_public(f'{TestAPI.API_HOST}')
 
 
 class TestClient(TestCase):

--- a/osfio-export-tool/tests/test_clitool.py
+++ b/osfio-export-tool/tests/test_clitool.py
@@ -5,8 +5,6 @@ import shutil
 import json
 import pdb  # Use pdb.set_trace() to help with debugging
 import traceback
-import random
-import string
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -69,10 +67,15 @@ class TestAPI(TestCase):
 
     def test_parse_single_project_json_as_expected(self):
         # Use first public project available for this test
+        # TODO: allow choosing individual components to start export from
+        # Currently a component will break this test
         data = call_api(
             f'{TestAPI.API_HOST}/nodes/',
             os.getenv('TEST_PAT', ''),
-            per_page=1
+            per_page=1,
+            filters={
+                'parent': ''
+            }
         )
         node = json.loads(data.read())['data'][0]
         id = extract_project_id(node['links']['html'])


### PR DESCRIPTION
Closes #19 

Allow a user to run the `export-projects` command without having to enter a PAT immediately (unless they give the `--pat` flag.)
If the user selects a public project to export, don't ask for a PAT.
If the user asks to export all their projects, or a single private project, then ask for a PAT.