### PR TITLE
61 stop very long text merging into each other

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Test on Pull Request
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -27,13 +27,14 @@ jobs:
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements.core.txt ]; then pip install -r requirements.core.txt; fi
+        pip install --editable .
     - name: Check linting quality
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 100 chars wide
         flake8 . --max-line-length=100 --statistics
-    - name: Run tests
+    - name: Run local tests
       run: |
           python -m unittest tests.test_clitool.TestExporter
           python -m unittest tests.test_clitool.TestCLI

--- a/src/osfexport/__init__.py
+++ b/src/osfexport/__init__.py
@@ -1,10 +1,16 @@
-from .exporter import (
+from osfexport.exporter import (
     call_api, get_project_data,
     explore_file_tree, explore_wikis,
-    is_public, extract_project_id
+    is_public, extract_project_id,
+    MockAPIResponse, get_nodes,
+    paginate_json_result
 )
 
-from .formatter import (
+from osfexport.cli import (
+    prompt_pat, cli
+)
+
+from osfexport.formatter import (
     write_pdf
 )
 
@@ -15,5 +21,10 @@ __all__ = [
     'explore_wikis',
     'write_pdf',
     'is_public',
-    'extract_project_id'
+    'extract_project_id',
+    'MockAPIResponse',
+    'get_nodes',
+    'paginate_json_result',
+    'extract_project_id',
+    'prompt_pat'
 ]

--- a/src/osfexport/__init__.py
+++ b/src/osfexport/__init__.py
@@ -26,5 +26,6 @@ __all__ = [
     'get_nodes',
     'paginate_json_result',
     'extract_project_id',
-    'prompt_pat'
+    'prompt_pat',
+    'cli'
 ]

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -3,8 +3,8 @@ import urllib.request as webhelper
 
 import click
 
-import src.osfexport.exporter as exporter
-import src.osfexport.formatter as formatter
+import osfexport.exporter as exporter
+import osfexport.formatter as formatter
 
 API_HOST_TEST = os.getenv('API_HOST_TEST', 'https://api.test.osf.io/v2')
 API_HOST_PROD = os.getenv('API_HOST_PROD', 'https://api.osf.io/v2')

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -523,11 +523,12 @@ def get_project_data(nodes, **kwargs):
             'category': get_category,
             'tags': get_tags,
             'resource_type': lambda project, **kwargs: 'NA',
-            'funders': lambda project, **kwargs: [],
+            'resource_lang': lambda project, **kwargs: 'NA',
             'affiliated_institutions': get_affiliated_institutions,
             'identifiers': get_identifiers,
             'license': get_license,
             'subjects': get_subjects,
+            'funders': lambda project, **kwargs: [],
         },
         'contributors': get_contributors
     }

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -18,6 +18,7 @@ FONT_SIZES = {
     'h5': 10  # Footer
 }
 LINE_PADDING = 0  # Gaps between lines
+CELL_WIDTH = 180  # Width of text cells
 
 
 class PDF(FPDF):
@@ -121,7 +122,7 @@ def write_pdf(projects, root_idx, folder=''):
             pdf.write(0, '\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h3'])
             pdf.multi_cell(
-                w=180, h=None,
+                w=CELL_WIDTH, h=None,
                 text=f'**{field_name}**\n',
                 align='L', markdown=True, padding=LINE_PADDING
             )
@@ -134,7 +135,7 @@ def write_pdf(projects, root_idx, folder=''):
                         field_name = subkey.replace('_', ' ').title()
 
                     pdf.multi_cell(
-                        w=180, h=None,
+                        w=CELL_WIDTH, h=None,
                         text=f'**{field_name}:** {item[subkey]}\n',
                         align='L', markdown=True, padding=LINE_PADDING
                     )
@@ -142,7 +143,7 @@ def write_pdf(projects, root_idx, folder=''):
         else:
             # Simple key-value attributes can go on one-line
             pdf.multi_cell(
-                w=180,
+                w=CELL_WIDTH,
                 h=None,
                 text=f'**{field_name}:** {fielddict[key]}\n',
                 align='L',
@@ -175,7 +176,7 @@ def write_pdf(projects, root_idx, folder=''):
         # Write parent header and title first
         if pdf.parent_title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-            pdf.multi_cell(w=180, h=None, text=f'{pdf.parent_title}\n', align='L')
+            pdf.multi_cell(w=CELL_WIDTH, h=None, text=f'{pdf.parent_title}\n', align='L')
         if pdf.parent_url:
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             pdf.cell(
@@ -191,7 +192,7 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_title != title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
             pdf.multi_cell(
-                w=180, h=None, text=f'{title}\n',
+                w=CELL_WIDTH, h=None, text=f'{title}\n',
                 align='L', padding=LINE_PADDING
             )
 
@@ -219,7 +220,7 @@ def write_pdf(projects, root_idx, folder=''):
         pdf.ln()
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
         pdf.multi_cell(
-            w=180, h=None, text='1. Project Metadata\n',
+            w=CELL_WIDTH, h=None, text='1. Project Metadata\n',
             align='L', padding=LINE_PADDING)
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         for key in project['metadata']:
@@ -228,7 +229,7 @@ def write_pdf(projects, root_idx, folder=''):
 
         # Write Contributors in table
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(w=180, h=None, text='2. Contributors\n', align='L')
+        pdf.multi_cell(w=CELL_WIDTH, h=None, text='2. Contributors\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         with pdf.table(
             headings_style=HEADINGS_STYLE,
@@ -254,9 +255,9 @@ def write_pdf(projects, root_idx, folder=''):
         # List files stored in storage providers
         # For now only OSF Storage is involved
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(w=180, h=None, text='3. Files in Main Project\n', align='L')
+        pdf.multi_cell(w=CELL_WIDTH, h=None, text='3. Files in Main Project\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h3'], style='B')
-        pdf.multi_cell(w=180, h=None, text='OSF Storage\n', align='L')
+        pdf.multi_cell(w=CELL_WIDTH, h=None, text='OSF Storage\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         if len(project['files']) > 0:
             with pdf.table(
@@ -281,18 +282,18 @@ def write_pdf(projects, root_idx, folder=''):
         else:
             pdf.write(0, '\n')
             pdf.multi_cell(
-                w=180, h=None, text='No files found for this project.\n', align='L'
+                w=CELL_WIDTH, h=None, text='No files found for this project.\n', align='L'
             )
             pdf.write(0, '\n')
 
         # Write wikis separately to more easily handle Markdown parsing
         pdf.ln()
         pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-        pdf.multi_cell(w=180, h=None, text='4. Wiki\n', align='L')
+        pdf.multi_cell(w=CELL_WIDTH, h=None, text='4. Wiki\n', align='L')
         pdf.ln()
         for i, wiki in enumerate(wikis.keys()):
             pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-            pdf.multi_cell(w=180, h=None, text=f'{wiki}\n')
+            pdf.multi_cell(w=CELL_WIDTH, h=None, text=f'{wiki}\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             html = markdown(wikis[wiki])
             pdf.write_html(html)

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -17,7 +17,7 @@ FONT_SIZES = {
     'h4': 12,  # Body
     'h5': 10  # Footer
 }
-LINE_PADDING = 0.5  # Gaps between liness
+LINE_PADDING = 0  # Gaps between lines
 
 
 class PDF(FPDF):
@@ -121,8 +121,8 @@ def write_pdf(projects, root_idx, folder=''):
             pdf.write(0, '\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h3'])
             pdf.multi_cell(
-                0, h=None,
-                text=f'**{field_name}**\n\n',
+                w=180, h=None,
+                text=f'**{field_name}**\n',
                 align='L', markdown=True, padding=LINE_PADDING
             )
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
@@ -134,17 +134,17 @@ def write_pdf(projects, root_idx, folder=''):
                         field_name = subkey.replace('_', ' ').title()
 
                     pdf.multi_cell(
-                        0, h=None,
-                        text=f'**{field_name}:** {item[subkey]}\n\n',
+                        w=180, h=None,
+                        text=f'**{field_name}:** {item[subkey]}\n',
                         align='L', markdown=True, padding=LINE_PADDING
                     )
                 pdf.write(0, '\n')
         else:
             # Simple key-value attributes can go on one-line
             pdf.multi_cell(
-                0,
+                w=180,
                 h=None,
-                text=f'**{field_name}:** {fielddict[key]}\n\n',
+                text=f'**{field_name}:** {fielddict[key]}\n',
                 align='L',
                 markdown=True,
                 padding=LINE_PADDING
@@ -175,14 +175,14 @@ def write_pdf(projects, root_idx, folder=''):
         # Write parent header and title first
         if pdf.parent_title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-            pdf.multi_cell(0, h=None, text=f'{pdf.parent_title}\n', align='L')
+            pdf.multi_cell(w=180, h=None, text=f'{pdf.parent_title}\n', align='L')
         if pdf.parent_url:
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             pdf.cell(
                 text='Main Project URL:', align='L'
             )
             pdf.cell(
-                text=f'{pdf.parent_url}\n', align='L', link=pdf.parent_url
+                text=f'{pdf.parent_url}', align='L', link=pdf.parent_url
             )
             pdf.write(0, '\n\n')
 
@@ -191,7 +191,7 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_title != title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
             pdf.multi_cell(
-                0, h=None, text=f'{title}\n',
+                w=180, h=None, text=f'{title}\n',
                 align='L', padding=LINE_PADDING
             )
 
@@ -215,23 +215,20 @@ def write_pdf(projects, root_idx, folder=''):
             )
             pdf.write(0, '\n\n')
 
-        pdf.ln()
-        pdf.ln()
-
         # Write title for metadata section, then actual fields
+        pdf.ln()
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
         pdf.multi_cell(
-            0, h=None, text='1. Project Metadata\n',
+            w=180, h=None, text='1. Project Metadata\n',
             align='L', padding=LINE_PADDING)
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         for key in project['metadata']:
             write_list_section(key, project['metadata'], pdf)
         pdf.write(0, '\n')
-        pdf.write(0, '\n')
 
         # Write Contributors in table
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(0, h=None, text='2. Contributors\n', align='L')
+        pdf.multi_cell(w=180, h=None, text='2. Contributors\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         with pdf.table(
             headings_style=HEADINGS_STYLE,
@@ -252,16 +249,14 @@ def write_pdf(projects, root_idx, folder=''):
                         row.cell(text=datum, link=datum)
                     else:
                         row.cell(datum)
-        pdf.write(0, '\n')
-        pdf.write(0, '\n')
+        pdf.write(0, '\n\n')
 
         # List files stored in storage providers
         # For now only OSF Storage is involved
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(0, h=None, text='3. Files in Main Project\n', align='L')
-        pdf.write(0, '\n')
+        pdf.multi_cell(w=180, h=None, text='3. Files in Main Project\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h3'], style='B')
-        pdf.multi_cell(0, h=None, text='OSF Storage\n', align='L')
+        pdf.multi_cell(w=180, h=None, text='OSF Storage\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         if len(project['files']) > 0:
             with pdf.table(
@@ -286,18 +281,18 @@ def write_pdf(projects, root_idx, folder=''):
         else:
             pdf.write(0, '\n')
             pdf.multi_cell(
-                0, h=None, text='No files found for this project.\n', align='L'
+                w=180, h=None, text='No files found for this project.\n', align='L'
             )
             pdf.write(0, '\n')
 
         # Write wikis separately to more easily handle Markdown parsing
         pdf.ln()
         pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-        pdf.multi_cell(0, h=None, text='4. Wiki\n', align='L')
+        pdf.multi_cell(w=180, h=None, text='4. Wiki\n', align='L')
         pdf.ln()
         for i, wiki in enumerate(wikis.keys()):
             pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-            pdf.multi_cell(0, h=None, text=f'{wiki}\n')
+            pdf.multi_cell(w=180, h=None, text=f'{wiki}\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             html = markdown(wikis[wiki])
             pdf.write_html(html)

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -121,7 +121,7 @@ def write_pdf(projects, root_idx, folder=''):
             pdf.write(0, '\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h3'])
             pdf.multi_cell(
-                0, h=0,
+                0, h=None,
                 text=f'**{field_name}**\n\n',
                 align='L', markdown=True, padding=LINE_PADDING
             )
@@ -134,7 +134,7 @@ def write_pdf(projects, root_idx, folder=''):
                         field_name = subkey.replace('_', ' ').title()
 
                     pdf.multi_cell(
-                        0, h=0,
+                        0, h=None,
                         text=f'**{field_name}:** {item[subkey]}\n\n',
                         align='L', markdown=True, padding=LINE_PADDING
                     )
@@ -143,7 +143,7 @@ def write_pdf(projects, root_idx, folder=''):
             # Simple key-value attributes can go on one-line
             pdf.multi_cell(
                 0,
-                h=0,
+                h=None,
                 text=f'**{field_name}:** {fielddict[key]}\n\n',
                 align='L',
                 markdown=True,
@@ -175,7 +175,7 @@ def write_pdf(projects, root_idx, folder=''):
         # Write parent header and title first
         if pdf.parent_title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-            pdf.multi_cell(0, h=0, text=f'{pdf.parent_title}\n', align='L')
+            pdf.multi_cell(0, h=None, text=f'{pdf.parent_title}\n', align='L')
         if pdf.parent_url:
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             pdf.cell(
@@ -191,7 +191,7 @@ def write_pdf(projects, root_idx, folder=''):
         if pdf.parent_title != title:
             pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
             pdf.multi_cell(
-                0, h=0, text=f'{title}\n',
+                0, h=None, text=f'{title}\n',
                 align='L', padding=LINE_PADDING
             )
 
@@ -221,7 +221,7 @@ def write_pdf(projects, root_idx, folder=''):
         # Write title for metadata section, then actual fields
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
         pdf.multi_cell(
-            0, h=0, text='1. Project Metadata\n',
+            0, h=None, text='1. Project Metadata\n',
             align='L', padding=LINE_PADDING)
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         for key in project['metadata']:
@@ -231,7 +231,7 @@ def write_pdf(projects, root_idx, folder=''):
 
         # Write Contributors in table
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(0, h=0, text='2. Contributors\n', align='L')
+        pdf.multi_cell(0, h=None, text='2. Contributors\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         with pdf.table(
             headings_style=HEADINGS_STYLE,
@@ -258,10 +258,10 @@ def write_pdf(projects, root_idx, folder=''):
         # List files stored in storage providers
         # For now only OSF Storage is involved
         pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-        pdf.multi_cell(0, h=0, text='3. Files in Main Project\n', align='L')
+        pdf.multi_cell(0, h=None, text='3. Files in Main Project\n', align='L')
         pdf.write(0, '\n')
         pdf.set_font(pdf.font, size=FONT_SIZES['h3'], style='B')
-        pdf.multi_cell(0, h=0, text='OSF Storage\n', align='L')
+        pdf.multi_cell(0, h=None, text='OSF Storage\n', align='L')
         pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
         if len(project['files']) > 0:
             with pdf.table(
@@ -286,18 +286,18 @@ def write_pdf(projects, root_idx, folder=''):
         else:
             pdf.write(0, '\n')
             pdf.multi_cell(
-                0, h=0, text='No files found for this project.\n', align='L'
+                0, h=None, text='No files found for this project.\n', align='L'
             )
             pdf.write(0, '\n')
 
         # Write wikis separately to more easily handle Markdown parsing
         pdf.ln()
         pdf.set_font(pdf.font, size=FONT_SIZES['h1'], style='B')
-        pdf.multi_cell(0, h=0, text='4. Wiki\n', align='L')
+        pdf.multi_cell(0, h=None, text='4. Wiki\n', align='L')
         pdf.ln()
         for i, wiki in enumerate(wikis.keys()):
             pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-            pdf.multi_cell(0, h=0, text=f'{wiki}\n')
+            pdf.multi_cell(0, h=None, text=f'{wiki}\n')
             pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
             html = markdown(wikis[wiki])
             pdf.write_html(html)

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -565,8 +565,8 @@ class TestExporter(TestCase):
         import_two = PdfReader(os.path.join(
             FOLDER_OUT, f'{title_two}-{date_two}.pdf'
         ))
-        assert len(import_one.pages) == 4, (
-            'Expected 4 pages in the first PDF, got: ',
+        assert len(import_one.pages) == 5, (
+            'Expected 5 pages in the first PDF, got: ',
             len(import_one.pages)
         )
 
@@ -576,7 +576,7 @@ class TestExporter(TestCase):
         content_second_page = import_two.pages[0].extract_text(
             extraction_mode='layout'
         )
-        content_third_page = import_one.pages[2].extract_text(
+        content_third_page = import_one.pages[3].extract_text(
             extraction_mode='layout'
         )
         assert f'{projects[0]['metadata']['title']}' in content_third_page, (

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -723,14 +723,14 @@ class TestExporter(TestCase):
 
 
 class TestCLI(TestCase):
-    @patch('src.osfexport.exporter.is_public', lambda x: True)
+    @patch('osfexport.exporter.is_public', lambda x: True)
     def test_prompt_pat_if_public_project_id_given(self):
         pat = prompt_pat('x')
         assert pat == '', (
             pat
         )
 
-    @patch('src.osfexport.exporter.is_public', lambda x: False)
+    @patch('osfexport.exporter.is_public', lambda x: False)
     @patch('click.prompt', return_value='strinput')
     def test_prompt_pat_if_private_project_id_given(self, mock_obj):
         pat = prompt_pat('x')

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from pypdf import PdfReader
 
-from src.osfexport.exporter import (
+from osfexport import (
     MockAPIResponse,
     call_api,
     get_project_data,
@@ -20,13 +20,9 @@ from src.osfexport.exporter import (
     explore_wikis,
     is_public,
     extract_project_id,
-    paginate_json_result
-)
-from src.osfexport.cli import (
-    cli, prompt_pat
-)
-from src.osfexport.formatter import (
-    write_pdf
+    paginate_json_result,
+    prompt_pat, write_pdf,
+    cli
 )
 
 TEST_PDF_FOLDER = 'good-pdfs'
@@ -696,7 +692,7 @@ class TestExporter(TestCase):
         url = ''
         project_id = extract_project_id(url)
 
-    @patch('src.osfexport.exporter.call_api')
+    @patch('osfexport.exporter.call_api')
     def test_add_on_paginated_results(self, mock_get):
         # Mock JSON responses
         page1 = {'data': 1, 'links': {'next': 'http://api.example.com/page2'}}
@@ -712,6 +708,7 @@ class TestExporter(TestCase):
         def add_x(json, **kwargs):
             x = kwargs.get('x', 0)
             return json['data'] + x
+        
 
         results = paginate_json_result(
             start='http://api.example.com/page1', action=add_x, x=5

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -708,7 +708,6 @@ class TestExporter(TestCase):
         def add_x(json, **kwargs):
             x = kwargs.get('x', 0)
             return json['data'] + x
-        
 
         results = paginate_json_result(
             start='http://api.example.com/page1', action=add_x, x=5


### PR DESCRIPTION
Addresses #61. Adjusts widths of text cells and uses methods with auto text wrapping.
Reorder appearance of PDF fields to make it clear which should be grouped together.
Attempted bug fixes with imports where different paths fail on local and GitHub workflow.