### PR TITLE
64 make exported wiki images fit to page

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Test on Pull Request
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -27,13 +27,14 @@ jobs:
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements.core.txt ]; then pip install -r requirements.core.txt; fi
+        pip install --editable .
     - name: Check linting quality
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 100 chars wide
         flake8 . --max-line-length=100 --statistics
-    - name: Run tests
+    - name: Run local tests
       run: |
           python -m unittest tests.test_clitool.TestExporter
           python -m unittest tests.test_clitool.TestCLI

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -3,8 +3,8 @@ import urllib.request as webhelper
 
 import click
 
-import src.osfexport.exporter as exporter
-import src.osfexport.formatter as formatter
+import osfexport.exporter as exporter
+import osfexport.formatter as formatter
 
 API_HOST_TEST = os.getenv('API_HOST_TEST', 'https://api.test.osf.io/v2')
 API_HOST_PROD = os.getenv('API_HOST_PROD', 'https://api.osf.io/v2')

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -308,11 +308,13 @@ class PDF(FPDF):
             wikis: dict
                 Dictionary containing wiki data to write.
         """
-        
-        self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
-        self.multi_cell(0, h=0, text='4. Wiki\n', align='L')
-        self.ln()
+
         for i, wiki in enumerate(wikis.keys()):
+            self.add_page()
+            if i == 0:
+                self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
+                self.multi_cell(0, h=0, text='4. Wiki\n', align='L')
+                self.ln()
             self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
             self.multi_cell(0, h=0, text=f'{wiki}\n')
             self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
@@ -321,8 +323,6 @@ class PDF(FPDF):
                 renderer=HTMLImageSizeCapRenderer
             )
             self.write_html(html)
-            if i < len(wikis.keys())-1:
-                self.add_page()
 
 
 def explore_project_tree(project, projects, pdf=None):

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -68,7 +68,7 @@ class PDF(FPDF):
         'h4': 12,  # Body
         'h5': 10  # Footer
     }
-    LINE_PADDING = 0.5  # Gaps between lines
+    LINE_PADDING = 0  # Gaps between lines
     CELL_WIDTH = 180  # Width of text cells
 
     def __init__(self, url='', parent_url='', parent_title=''):
@@ -267,7 +267,6 @@ class PDF(FPDF):
         # For now only OSF Storage is involved
         self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
         self.multi_cell(w=PDF.CELL_WIDTH, h=None, text='3. Files in Main Project\n', align='L')
-        self.write(0, '\n')
         self.set_font(self.font, size=PDF.FONT_SIZES['h3'], style='B')
         self.multi_cell(w=PDF.CELL_WIDTH, h=None, text='OSF Storage\n', align='L')
         self.set_font(self.font, size=PDF.FONT_SIZES['h4'])

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -312,13 +312,19 @@ class PDF(FPDF):
         """
 
         for i, wiki in enumerate(wikis.keys()):
+            self.add_page()
+            if i == 0:
+                self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
+                self.multi_cell(w=PDF.CELL_WIDTH, h=None, text='4. Wiki\n', align='L')
+                self.ln()
             self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
             self.multi_cell(w=PDF.CELL_WIDTH, h=None, text=f'{wiki}\n')
             self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
-            html = markdown(wikis[wiki])
+            html = markdown(
+                wikis[wiki],
+                renderer=HTMLImageSizeCapRenderer
+            )
             self.write_html(html)
-            if i < len(wikis.keys())-1:
-                self.add_page()
 
 
 def explore_project_tree(project, projects, pdf=None):

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -312,15 +312,14 @@ class PDF(FPDF):
         """
 
         for i, wiki in enumerate(wikis.keys()):
-            pdf.set_font(pdf.font, size=FONT_SIZES['h2'], style='B')
-            pdf.multi_cell(w=PDF.CELL_WIDTH, h=None, text=f'{wiki}\n')
-            pdf.set_font(pdf.font, size=FONT_SIZES['h4'])
+            self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
+            self.multi_cell(w=PDF.CELL_WIDTH, h=None, text=f'{wiki}\n')
+            self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
             html = markdown(wikis[wiki])
-            pdf.write_html(html)
+            self.write_html(html)
             if i < len(wikis.keys())-1:
-                pdf.add_page()
+                self.add_page()
 
-        return pdf
 
 def explore_project_tree(project, projects, pdf=None):
     """Recursively find child projects and write them to a PDF.

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -5,6 +5,7 @@ import html
 
 from fpdf import FPDF, Align
 from fpdf.fonts import FontFace
+from fpdf.image_parsing import get_img_info
 from mistletoe import markdown, HTMLRenderer
 import qrcode
 
@@ -21,8 +22,21 @@ class HTMLImageSizeCapRenderer(HTMLRenderer):
         """Render an image with a specified size."""
 
         template = '<img src="{}" alt="{}"{}{}{} />'
-        width = ' width="{}"'.format(html.escape(str(HTMLImageSizeCapRenderer.max_width)))
-        height = ' height="{}"'.format(html.escape(str(HTMLImageSizeCapRenderer.max_height)))
+
+        # Cap image size if needed so they can fit on the page
+        img_info = get_img_info(token.src)
+        if img_info['w'] > HTMLImageSizeCapRenderer.max_width:
+            new_width = HTMLImageSizeCapRenderer.max_width
+        else:
+            new_width = img_info['w']
+        width = ' width="{}"'.format(html.escape(str(new_width)))
+        
+        if img_info['h'] > HTMLImageSizeCapRenderer.max_height:
+            new_height = HTMLImageSizeCapRenderer.max_height
+        else:
+            new_height = img_info['h']
+        height = ' height="{}"'.format(html.escape(str(new_height)))
+        
         if token.title:
             title = ' title="{}"'.format(html.escape(token.title))
         else:

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -7,18 +7,6 @@ from fpdf.fonts import FontFace
 from mistletoe import markdown
 import qrcode
 
-# Global styles for PDF
-BLUE = (173, 216, 230)
-HEADINGS_STYLE = FontFace(emphasis="BOLD", fill_color=BLUE)
-FONT_SIZES = {
-    'h1': 18,  # Project titles
-    'h2': 16,  # Section titles
-    'h3': 14,  # Section sub-titles
-    'h4': 12,  # Body
-    'h5': 10  # Footer
-}
-LINE_PADDING = 0.5  # Gaps between lines
-
 
 class PDF(FPDF):
     """Custom PDF class to implement extra customisation.
@@ -32,6 +20,18 @@ class PDF(FPDF):
         parent_title: str
             Title of root project to use in component sections.
     """
+
+    # Global styles for PDF
+    BLUE = (173, 216, 230)
+    HEADINGS_STYLE = FontFace(emphasis="BOLD", fill_color=BLUE)
+    FONT_SIZES = {
+        'h1': 18,  # Project titles
+        'h2': 16,  # Section titles
+        'h3': 14,  # Section sub-titles
+        'h4': 12,  # Body
+        'h5': 10  # Footer
+    }
+    LINE_PADDING = 0.5  # Gaps between lines
 
     def __init__(self, url='', parent_url='', parent_title=''):
         super().__init__()
@@ -60,7 +60,7 @@ class PDF(FPDF):
     def footer(self):
         self.set_y(-15)
         self.set_x(-30)
-        self.set_font(self.font, size=FONT_SIZES['h5'])
+        self.set_font(self.font, size=PDF.FONT_SIZES['h5'])
         self.cell(0, 10, f"Page: {self.page_no()}", align="C")
         self.set_x(10)
         timestamp = self.date_printed.strftime(
@@ -97,13 +97,13 @@ class PDF(FPDF):
         if isinstance(fielddict[key], list):
             # Create separate paragraphs for more complex attributes
             self.write(0, '\n')
-            self.set_font(self.font, size=FONT_SIZES['h3'])
+            self.set_font(self.font, size=PDF.FONT_SIZES['h3'])
             self.multi_cell(
                 0, h=0,
                 text=f'**{field_name}**\n\n',
-                align='L', markdown=True, padding=LINE_PADDING
+                align='L', markdown=True, padding=PDF.LINE_PADDING
             )
-            self.set_font(self.font, size=FONT_SIZES['h4'])
+            self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
             for item in fielddict[key]:
                 for subkey in item.keys():
                     if subkey in pdf_display_names:
@@ -114,7 +114,7 @@ class PDF(FPDF):
                     self.multi_cell(
                         0, h=0,
                         text=f'**{field_name}:** {item[subkey]}\n\n',
-                        align='L', markdown=True, padding=LINE_PADDING
+                        align='L', markdown=True, padding=PDF.LINE_PADDING
                     )
                 self.write(0, '\n')
         else:
@@ -125,7 +125,7 @@ class PDF(FPDF):
                 text=f'**{field_name}:** {fielddict[key]}\n\n',
                 align='L',
                 markdown=True,
-                padding=LINE_PADDING
+                padding=PDF.LINE_PADDING
             )
     
     def _write_project_body(self, project):
@@ -143,16 +143,15 @@ class PDF(FPDF):
         self.set_line_width(0.05)
         self.set_left_margin(10)
         self.set_right_margin(10)
-        self.set_font(self.font, size=FONT_SIZES['h4'])
+        self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
         wikis = project['wikis']
 
-        # Write header section
-        # Write parent header and title first
+        # Start with parent, project headers and links
         if self.parent_title:
-            self.set_font(self.font, size=FONT_SIZES['h1'], style='B')
+            self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
             self.multi_cell(0, h=0, text=f'{self.parent_title}\n', align='L')
         if self.parent_url:
-            self.set_font(self.font, size=FONT_SIZES['h4'])
+            self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
             self.cell(
                 text='Main Project URL:', align='L'
             )
@@ -160,24 +159,21 @@ class PDF(FPDF):
                 text=f'{self.parent_url}\n', align='L', link=self.parent_url
             )
             self.write(0, '\n\n')
-
         # Check if title, url is of parent's to avoid duplication
         title = project['metadata']['title']
         if self.parent_title != title:
-            self.set_font(self.font, size=FONT_SIZES['h1'], style='B')
+            self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
             self.multi_cell(
                 0, h=0, text=f'{title}\n',
-                align='L', padding=LINE_PADDING
+                align='L', padding=PDF.LINE_PADDING
             )
 
         # Pop URL field to avoid printing it out in Metadata section
         url = project['metadata'].pop('url', '')
-
         self.url = url  # Set current URL to use in QR codes
         qr_img = self.generate_qr_code()
         self.image(qr_img, w=30, x=Align.R, y=5)
-
-        self.set_font(self.font, size=FONT_SIZES['h4'])
+        self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
         if url and self.parent_url != url:
             self.cell(
                 text='Component URL:',
@@ -189,27 +185,26 @@ class PDF(FPDF):
                 link=url
             )
             self.write(0, '\n\n')
-
         self.ln()
         self.ln()
 
         # Write title for metadata section, then actual fields
-        self.set_font(self.font, size=FONT_SIZES['h2'], style='B')
+        self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
         self.multi_cell(
             0, h=0, text='1. Project Metadata\n',
-            align='L', padding=LINE_PADDING)
-        self.set_font(self.font, size=FONT_SIZES['h4'])
+            align='L', padding=PDF.LINE_PADDING)
+        self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
         for key in project['metadata']:
             self._write_list_section(key, project['metadata'])
         self.write(0, '\n')
         self.write(0, '\n')
 
         # Write Contributors in table
-        self.set_font(self.font, size=FONT_SIZES['h2'], style='B')
+        self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
         self.multi_cell(0, h=0, text='2. Contributors\n', align='L')
-        self.set_font(self.font, size=FONT_SIZES['h4'])
+        self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
         with self.table(
-            headings_style=HEADINGS_STYLE,
+            headings_style=PDF.HEADINGS_STYLE,
             col_widths=(1, 0.5, 1)
         ) as table:
             row = table.row()
@@ -232,15 +227,15 @@ class PDF(FPDF):
 
         # List files stored in storage providers
         # For now only OSF Storage is involved
-        self.set_font(self.font, size=FONT_SIZES['h2'], style='B')
+        self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
         self.multi_cell(0, h=0, text='3. Files in Main Project\n', align='L')
         self.write(0, '\n')
-        self.set_font(self.font, size=FONT_SIZES['h3'], style='B')
+        self.set_font(self.font, size=PDF.FONT_SIZES['h3'], style='B')
         self.multi_cell(0, h=0, text='OSF Storage\n', align='L')
-        self.set_font(self.font, size=FONT_SIZES['h4'])
+        self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
         if len(project['files']) > 0:
             with self.table(
-                headings_style=HEADINGS_STYLE,
+                headings_style=PDF.HEADINGS_STYLE,
                 col_widths=(1, 0.5, 1)
             ) as table:
                 row = table.row()
@@ -264,16 +259,27 @@ class PDF(FPDF):
                 0, h=0, text='No files found for this project.\n', align='L'
             )
             self.write(0, '\n')
-
+        
         # Write wikis separately to more easily handle Markdown parsing
         self.ln()
-        self.set_font(self.font, size=FONT_SIZES['h1'], style='B')
+        self._write_wiki_pages(wikis)
+    
+    def _write_wiki_pages(self, wikis):
+        """Write inplace the wiki pages to the PDF.
+
+        Parameters
+        -----------
+            wikis: dict
+                Dictionary containing wiki data to write.
+        """
+        
+        self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
         self.multi_cell(0, h=0, text='4. Wiki\n', align='L')
         self.ln()
         for i, wiki in enumerate(wikis.keys()):
-            self.set_font(self.font, size=FONT_SIZES['h2'], style='B')
+            self.set_font(self.font, size=PDF.FONT_SIZES['h2'], style='B')
             self.multi_cell(0, h=0, text=f'{wiki}\n')
-            self.set_font(self.font, size=FONT_SIZES['h4'])
+            self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
             html = markdown(wikis[wiki])
             self.write_html(html)
             if i < len(wikis.keys())-1:

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -632,8 +632,8 @@ class TestFormatter(TestCase):
         import_two = PdfReader(os.path.join(
             FOLDER_OUT, f'{title_two}-{date_two}.pdf'
         ))
-        assert len(import_one.pages) == 4, (
-            'Expected 4 pages in the first PDF, got: ',
+        assert len(import_one.pages) == 5, (
+            'Expected 5 pages in the first PDF, got: ',
             len(import_one.pages)
         )
 
@@ -643,7 +643,7 @@ class TestFormatter(TestCase):
         content_second_page = import_two.pages[0].extract_text(
             extraction_mode='layout'
         )
-        content_third_page = import_one.pages[2].extract_text(
+        content_third_page = import_one.pages[3].extract_text(
             extraction_mode='layout'
         )
         assert f'{projects[0]['metadata']['title']}' in content_third_page, (
@@ -658,14 +658,12 @@ class TestFormatter(TestCase):
         assert f'{url}' in content_first_page, (
             content_third_page
         )
-
         assert 'Category: Uncategorized' in content_first_page, (
             content_first_page
         )
         assert 'Category: Methods and Measures' in content_second_page, (
             content_second_page
         )
-
         timestamp = pdf_one.date_printed.strftime(
             '%Y-%m-%d %H:%M:%S %Z')
         assert f'Exported: {timestamp}' in content_first_page, (
@@ -676,7 +674,6 @@ class TestFormatter(TestCase):
         # This way of string formatting compresses line lengths used
         # End of headers and table rows marked by \n\n
         contributors_table = (
-            'Subjects: sub1, sub2, sub3\n\n'
             '2. Contributors\n\n'
             'Name'
             'Bibliographic?'
@@ -690,7 +687,6 @@ class TestFormatter(TestCase):
             'Margarine'
             'Yes'
             'https://test.osf.io/userid/\n\n'
-            '3. Files in Main Project'
         ).replace(' ', '')
         assert contributors_table in content_first_page.replace(' ', ''), (
             'Table: ',
@@ -713,7 +709,6 @@ class TestFormatter(TestCase):
             'file2.txt'
             'N/A'
             'N/A\n\n'
-            '4. Wiki'
         ).replace(' ', '')
         assert files_table in content_first_page.replace(' ', ''), (
             'Table: ',

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -26,7 +26,7 @@ from osfexport.cli import (
     cli, prompt_pat
 )
 from osfexport.formatter import (
-    write_pdf
+    write_pdf, PDF
 )
 
 TEST_PDF_FOLDER = 'good-pdfs'
@@ -725,22 +725,52 @@ class TestFormatter(TestCase):
         os.remove(path_one)
         os.remove(path_two)
     
-    # def test_write_image_with_size_into_pdf(self):
-    #     markdown = """
-    #     This has an image in the wiki page.
-    #     ![Someone taking a pic on their phone camera][1]This is an image above this text.
-        
-    #     Another paragraph.
-        
-    #     Another image:
-    #     ![enter image description here][2]
-        
-    #     [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png
-    #     [2]: https://upload.wikimedia.org/wikipedia/commons/6/6e/Abundant_Crop_-_geograph.org.uk_-_510746.jpg
-    #     """
-    #     pdf = 
-    #     assert False
+    def test_write_image_with_size_into_pdf(self):
+        markdown = """"This has an image in the wiki page.
+![Someone taking a pic on their phone camera][1]This is an image above this text.
+Another paragraph.
 
+  [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png"""
+#         markdown_page2 = """![enter image description here][1]
+
+
+# [1]: https://files.us.test.osf.io/v1/resources/4a5fs/providers/osfstorage/68a5f5d97f532e0f0bf8dd30?mode=render"""
+
+        pdf = PDF()
+        pdf._write_project_body({
+            'metadata': {
+                'title': 'Test Project',
+                'id': 'test-id',
+                'url': 'https://test.osf.io/test-id',
+                'category': 'Uncategorized',
+                'description': 'This is a test project with images.',
+                'date_created': datetime.datetime.now(),
+                'date_modified': datetime.datetime.now(),
+                'tags': '',
+                'resource_type': '',
+                'resource_lang': '',
+                'affiliated_institutions': '',
+                'identifiers': '',
+                'license': '',
+                'subjects': ''
+            },
+            'contributors': [],
+            'files': [],
+            'funders': [],
+            'wikis': {'Home': markdown},
+            "parent": None,
+            'children': []
+        })
+        pdf_output_path = 'test_project.pdf'
+        pdf.output(pdf_output_path)
+        try:
+            assert os.path.exists(pdf_output_path), (
+                'PDF file was not created.'
+            )
+            #os.remove(pdf_output_path)
+        except AssertionError as e:
+            #os.remove(pdf_output_path)
+            raise e
 
 class TestCLI(TestCase):
     @patch('osfexport.exporter.is_public', lambda x: True)

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from pypdf import PdfReader
 
-from osfexport import (
+from osfexport.exporter import (
     MockAPIResponse,
     call_api,
     get_project_data,
@@ -20,9 +20,6 @@ from osfexport import (
     explore_wikis,
     is_public,
     extract_project_id,
-    paginate_json_result,
-    prompt_pat, write_pdf,
-    cli,
     paginate_json_result
 )
 from osfexport.cli import (

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -726,41 +726,15 @@ class TestFormatter(TestCase):
         os.remove(path_two)
     
     def test_write_image_with_size_into_pdf(self):
-        markdown = """"This has an image in the wiki page.
+        markdown = """This has an image in the wiki page.
 ![Someone taking a pic on their phone camera][1]This is an image above this text.
 Another paragraph.
 
   [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png"""
-#         markdown_page2 = """![enter image description here][1]
-
-
-# [1]: https://files.us.test.osf.io/v1/resources/4a5fs/providers/osfstorage/68a5f5d97f532e0f0bf8dd30?mode=render"""
 
         pdf = PDF()
-        pdf._write_project_body({
-            'metadata': {
-                'title': 'Test Project',
-                'id': 'test-id',
-                'url': 'https://test.osf.io/test-id',
-                'category': 'Uncategorized',
-                'description': 'This is a test project with images.',
-                'date_created': datetime.datetime.now(),
-                'date_modified': datetime.datetime.now(),
-                'tags': '',
-                'resource_type': '',
-                'resource_lang': '',
-                'affiliated_institutions': '',
-                'identifiers': '',
-                'license': '',
-                'subjects': ''
-            },
-            'contributors': [],
-            'files': [],
-            'funders': [],
-            'wikis': {'Home': markdown},
-            "parent": None,
-            'children': []
-        })
+        pdf.add_page()
+        pdf._write_wiki_pages({'Home': markdown})
         pdf_output_path = 'test_project.pdf'
         pdf.output(pdf_output_path)
         try:

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -727,7 +727,7 @@ class TestFormatter(TestCase):
 ![Someone taking a pic on their phone camera][1]This is an image above this text.
 Another paragraph.
 
-  [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png"""
+  [1]: https://tinyurl.com/3453t48r"""
 
         HTMLImageSizeCapRenderer.max_width = 200
         HTMLImageSizeCapRenderer.max_height = 200

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -720,7 +720,7 @@ class TestFormatter(TestCase):
         # Remove files only if all good - keep for debugging otherwise
         os.remove(path_one)
         os.remove(path_two)
-    
+
     def test_write_image_html_with_new_size(self):
         # Use a large image - should be resized
         text = """This has an image in the wiki page.
@@ -728,18 +728,20 @@ class TestFormatter(TestCase):
 Another paragraph.
 
   [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png"""
-        
+
         HTMLImageSizeCapRenderer.max_width = 200
         HTMLImageSizeCapRenderer.max_height = 200
         html = markdown(
             text,
             renderer=HTMLImageSizeCapRenderer
         )
+        expected_width = HTMLImageSizeCapRenderer.max_width
+        expected_height = HTMLImageSizeCapRenderer.max_width
         expected_html = (
             '<p>This has an image in the wiki page.\n'
-            '<img src="https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png" '
+            '<img src="https://tinyurl.com/3453t48r" '
             'alt="Someone taking a pic on their phone camera" '
-            f'width="{HTMLImageSizeCapRenderer.max_width}" height="{HTMLImageSizeCapRenderer.max_width}" />'
+            f'width="{expected_height}" height="{expected_width}" />'
             'This is an image above this text.\n'
             'Another paragraph.</p>\n'
         )
@@ -778,6 +780,7 @@ Another paragraph.
             'Actual HTML: ',
             html
         )
+
 
 class TestCLI(TestCase):
     @patch('osfexport.exporter.is_public', lambda x: True)

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -727,15 +727,15 @@ class TestFormatter(TestCase):
         os.remove(path_two)
     
     def test_write_image_html_with_new_size(self):
+        # Use a large image - should be resized
         text = """This has an image in the wiki page.
 ![Someone taking a pic on their phone camera][1]This is an image above this text.
 Another paragraph.
 
   [1]: https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png"""
         
-        HTMLImageSizeCapRenderer.max_width = 400
-        HTMLImageSizeCapRenderer.max_height = 400
-
+        HTMLImageSizeCapRenderer.max_width = 200
+        HTMLImageSizeCapRenderer.max_height = 200
         html = markdown(
             text,
             renderer=HTMLImageSizeCapRenderer
@@ -745,6 +745,35 @@ Another paragraph.
             '<img src="https://upload.wikimedia.org/wikipedia/commons/b/b6/Image_created_with_a_mobile_phone.png" '
             'alt="Someone taking a pic on their phone camera" '
             f'width="{HTMLImageSizeCapRenderer.max_width}" height="{HTMLImageSizeCapRenderer.max_width}" />'
+            'This is an image above this text.\n'
+            'Another paragraph.</p>\n'
+        )
+        assert html == expected_html, (
+            'Expected HTML: ',
+            expected_html,
+            'Actual HTML: ',
+            html
+        )
+
+        # Use a 300x300 image - should not be resized
+        text = """This has an image in the wiki page.
+![Someone taking a pic on their phone camera][1]This is an image above this text.
+Another paragraph.
+
+  [1]: https://upload.wikimedia.org/wikipedia/commons/3/3c/300_x_300.png"""
+        HTMLImageSizeCapRenderer.max_width = 800
+        HTMLImageSizeCapRenderer.max_height = 400
+        html = markdown(
+            text,
+            renderer=HTMLImageSizeCapRenderer
+        )
+        expected_width = 300
+        expected_height = 300
+        expected_html = (
+            '<p>This has an image in the wiki page.\n'
+            '<img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/300_x_300.png" '
+            'alt="Someone taking a pic on their phone camera" '
+            f'width="{expected_width}" height="{expected_height}" />'
             'This is an image above this text.\n'
             'Another paragraph.</p>\n'
         )

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -369,7 +369,7 @@ class TestExporter(TestCase):
         url = ''
         project_id = extract_project_id(url)
 
-    @patch('src.osfexport.exporter.call_api')
+    @patch('osfexport.exporter.call_api')
     def test_add_on_paginated_results(self, mock_get):
         # Mock JSON responses
         page1 = {'data': 1, 'links': {'next': 'http://api.example.com/page2'}}
@@ -743,14 +743,14 @@ class TestFormatter(TestCase):
 
 
 class TestCLI(TestCase):
-    @patch('src.osfexport.exporter.is_public', lambda x: True)
+    @patch('osfexport.exporter.is_public', lambda x: True)
     def test_prompt_pat_if_public_project_id_given(self):
         pat = prompt_pat('x')
         assert pat == '', (
             pat
         )
 
-    @patch('src.osfexport.exporter.is_public', lambda x: False)
+    @patch('osfexport.exporter.is_public', lambda x: False)
     @patch('click.prompt', return_value='strinput')
     def test_prompt_pat_if_private_project_id_given(self, mock_obj):
         pat = prompt_pat('x')

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -22,7 +22,7 @@ from osfexport import (
     extract_project_id,
     paginate_json_result,
     prompt_pat, write_pdf,
-    cli
+    cli,
     paginate_json_result
 )
 from osfexport.cli import (


### PR DESCRIPTION
Fixes #64 by adding a custom Markdown to HTML renderer, `HTMLImageSizeCapRenderer`, that can resize images before being added to the final PDF.