### PR TITLE
76 add user agent header to requests

### DIFF
--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -1,6 +1,4 @@
 import os
-import urllib.request as webhelper
-import importlib.metadata
 
 import click
 
@@ -113,7 +111,7 @@ def show_welcome(pat, usetest):
         api_host = API_HOST_TEST
     else:
         api_host = API_HOST_PROD
-    
+
     result = exporter.call_api(f'{api_host}/', pat=pat, method='GET')
     click.echo(result.read())
     click.echo(result.status)

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -113,12 +113,8 @@ def show_welcome(pat, usetest):
         api_host = API_HOST_TEST
     else:
         api_host = API_HOST_PROD
-
-    request = webhelper.Request(f'{api_host}/', method='GET')
-    request.add_header('Authorization', f'Bearer {pat}')
-    version = importlib.metadata.version("osfio-export-tool")
-    request.add_header('User-Agent', f'osfio-export-tool/{version} (Python)')
-    result = webhelper.urlopen(request)
+    
+    result = exporter.call_api(f'{api_host}/', pat=pat, method='GET')
     click.echo(result.read())
     click.echo(result.status)
 

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -1,5 +1,6 @@
 import os
 import urllib.request as webhelper
+import importlib.metadata
 
 import click
 
@@ -115,6 +116,8 @@ def show_welcome(pat, usetest):
 
     request = webhelper.Request(f'{api_host}/', method='GET')
     request.add_header('Authorization', f'Bearer {pat}')
+    version = importlib.metadata.version("osfio-export-tool")
+    request.add_header('User-Agent', f'osfio-export-tool/{version} (Python)')
     result = webhelper.urlopen(request)
     click.echo(result.read())
     click.echo(result.status)

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -155,11 +155,10 @@ def is_public(url):
         The URL to test.
     """
 
-    request = webhelper.Request(url, method='GET')
-    version = importlib.metadata.version("osfio-export-tool")
-    request.add_header('User-Agent', f'osfio-export-tool/{version} (Python)')
     try:
-        result = webhelper.urlopen(request).status
+        result = call_api(
+            url, pat='', method='GET'
+        ).status
     except webhelper.HTTPError as e:
         result = e
     return result == 200

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -3,6 +3,8 @@ import json
 import os
 import datetime
 import urllib.request as webhelper
+import importlib.metadata
+
 
 API_HOST_TEST = os.getenv('API_HOST_TEST', 'https://api.test.osf.io/v2')
 API_HOST_PROD = os.getenv('API_HOST_PROD', 'https://api.osf.io/v2')
@@ -154,6 +156,8 @@ def is_public(url):
     """
 
     request = webhelper.Request(url, method='GET')
+    version = importlib.metadata.version("osfio-export-tool")
+    request.add_header('User-Agent', f'osfio-export-tool/{version} (Python)')
     try:
         result = webhelper.urlopen(request).status
     except webhelper.HTTPError as e:
@@ -198,6 +202,9 @@ def call_api(url, pat, method='GET', per_page=100, filters={}, is_json=True):
 
     request = webhelper.Request(url, method=method)
     request.add_header('Authorization', f'Bearer {pat}')
+
+    version = importlib.metadata.version("osfio-export-tool")
+    request.add_header('User-Agent', f'osfio-export-tool/{version} (Python)')
 
     # Pin API version so that JSON has correct format
     API_VERSION = '2.20'

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -126,12 +126,11 @@ class TestExporter(TestCase):
         call_api('https://test.osf.io', pat='pat', is_json=True)
         version = importlib.metadata.version("osfio-export-tool")
         expected_calls = [
-            call().add_header('Authorization', f'Bearer pat'),
+            call().add_header('Authorization', 'Bearer pat'),
             call().add_header('User-Agent', f'osfio-export-tool/{version} (Python)'),
             call().add_header('Accept', 'application/vnd.api+json;version=2.20')
         ]
         mock_request_class.assert_has_calls(expected_calls, any_order=False)
-
 
     def test_get_public_status(self):
         # Public url

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -6,7 +6,7 @@ import shutil
 import json
 # import pdb  # Use pdb.set_trace() to help with debugging
 import traceback
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 from pypdf import PdfReader
@@ -115,6 +115,29 @@ class TestAPI(TestCase):
 
 class TestExporter(TestCase):
     """Tests for the exporter without real API usage."""
+
+    def test_get_public_status(self):
+        # Public url
+        mock_response = MagicMock()
+        mock_response.status = 200
+        with patch('osfexport.exporter.call_api') as mock_call_api:
+            mock_call_api.return_value = mock_response
+            result = is_public('url')
+            mock_call_api.assert_called_once_with(
+                'url', pat='', method='GET'
+            )
+            assert result is True
+
+        # Private url
+        mock_response = MagicMock()
+        mock_response.status = 401
+        with patch('osfexport.exporter.call_api') as mock_call_api:
+            mock_call_api.return_value = mock_response
+            result = is_public('url')
+            mock_call_api.assert_called_once_with(
+                'url', pat='', method='GET'
+            )
+            assert result is False
 
     def test_explore_mock_file_tree(self):
         files = explore_file_tree(


### PR DESCRIPTION
Closes #76. 
The `call_api` method now adds User-Agent headers to identify requests being from this library. Some refactoring done to remove duplication of handling requests and headers done in `call_api`. Added unit and regression tests to enforce expected headers and use of `call_api`.