### PR TITLE
86 show title of direct parent when including components of a project

### DIFF
--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -602,24 +602,23 @@ def get_project_data(nodes, **kwargs):
                 root_nodes.append(idx)
             
             elif project_data['parent'] is None:
-                # If first project is a component, try to get its parent's title
-                project_data['parent'] = [
-                    '',
-                    project['relationships']['parent'][
+                parent_link = project['relationships']['parent'][
                     'links']['related']['href']
-                ]
                 try:
                     if not dryrun:
                         parent = json.loads(
                             call_api(
-                                project_data['parent'][1],
+                                parent_link,
                                 pat=pat,
                                 is_json=True
                             )
                         ).read()
                     else:
-                        parent = MockAPIResponse.read(project_data['parent'][1])
-                    project_data['parent'][0] = parent['data']['attributes']['title']
+                        parent = MockAPIResponse.read(parent_link)
+                    project_data['parent'] = (
+                        parent['data']['attributes']['title'],
+                        parent['data']['links']['html']
+                    )
                 except (webhelper.HTTPError, ValueError):
                     print("Failed to load parent, leaving title blank")
 

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -611,8 +611,8 @@ def get_project_data(nodes, **kwargs):
                                 parent_link,
                                 pat=pat,
                                 is_json=True
-                            )
-                        ).read()
+                            ).read()
+                        )
                     else:
                         parent = MockAPIResponse.read(parent_link)
                     project_data['parent'] = (
@@ -620,7 +620,8 @@ def get_project_data(nodes, **kwargs):
                         parent['data']['links']['html']
                     )
                 except (webhelper.HTTPError, ValueError):
-                    print("Failed to load parent, leaving title blank")
+                    print(f"Failed to load parent for {project_data['metadata']['title']}")
+                    print(f"Try to give a PAT beforehand using the --pat flag.", "\n")
 
         # Projects specified by ID to export also count as start nodes for PDFs
         # This will be the first node in list of root nodes

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -606,7 +606,6 @@ def get_project_data(nodes, **kwargs):
             # In general, start nodes for PDFs have no parents
             if 'links' not in project['relationships']['parent']:
                 root_nodes.append(idx)
-            
             elif project_data['parent'] is None:
                 parent_link = project['relationships']['parent'][
                     'links']['related']['href']
@@ -627,7 +626,7 @@ def get_project_data(nodes, **kwargs):
                     )
                 except (webhelper.HTTPError, ValueError):
                     print(f"Failed to load parent for {project_data['metadata']['title']}")
-                    print(f"Try to give a PAT beforehand using the --pat flag.", "\n")
+                    print("Try to give a PAT beforehand using the --pat flag.", "\n")
 
         # Projects specified by ID to export also count as start nodes for PDFs
         # This will be the first node in list of root nodes
@@ -644,7 +643,7 @@ def get_project_data(nodes, **kwargs):
                 children.append(child['id'])
                 nodes['data'].append(child)  # Add to list of nodes to search
             return children
-        
+
         children_link = relations['children']['links']['related']['href']
         children = list(paginate_json_result(
             children_link, dryrun=dryrun, pat=pat, action=get_children

--- a/src/osfexport/formatter.py
+++ b/src/osfexport/formatter.py
@@ -71,11 +71,9 @@ class PDF(FPDF):
     LINE_PADDING = 0  # Gaps between lines
     CELL_WIDTH = 180  # Width of text cells
 
-    def __init__(self, url='', parent_url='', parent_title=''):
+    def __init__(self, url=''):
         super().__init__()
         self.date_printed = datetime.datetime.now().astimezone()
-        self.parent_url = parent_url
-        self.parent_title = parent_title
         self.url = url
         # Setup unicode font for use. Can have 4 styles
         self.font = 'dejavu-sans'
@@ -185,36 +183,25 @@ class PDF(FPDF):
         wikis = project['wikis']
 
         # Start with parent, project headers and links
-        if self.parent_title:
+        parent = project['parent']
+        if parent:
             self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
-            self.multi_cell(w=PDF.CELL_WIDTH, h=None, text=f'{self.parent_title}\n', align='L')
-        if self.parent_url:
+            self.multi_cell(w=PDF.CELL_WIDTH, h=None, text=f'Parent: {parent[0]}\n', align='L')
             self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
             self.cell(
-                text='Main Project URL:', align='L'
+                text='Parent URL:', align='L'
             )
             self.cell(
-                text=f'{self.parent_url}\n', align='L', link=self.parent_url
+                text=f'{parent[1]}\n', align='L', link=parent[1]
             )
             self.write(0, '\n\n')
-        # Check if title, url is of parent's to avoid duplication
+
         title = project['metadata']['title']
-        if self.parent_title != title:
-            self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
-            self.multi_cell(
-                w=PDF.CELL_WIDTH, h=None, text=f'{title}\n',
-                align='L', padding=PDF.LINE_PADDING
-            )
-        # Add link to parent if top-level project is a component
-        else:
-            if project['parent']:
-                self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
-                self.cell(
-                    text='Component of:', align='L'
-                )
-            self.cell(
-                text=f'{project['parent']}\n', align='L', link=project['parent']
-            )
+        self.set_font(self.font, size=PDF.FONT_SIZES['h1'], style='B')
+        self.multi_cell(
+            w=PDF.CELL_WIDTH, h=None, text=f'{title}\n',
+            align='L', padding=PDF.LINE_PADDING
+        )
 
         # Pop URL field to avoid printing it out in Metadata section
         url = project['metadata'].pop('url', '')
@@ -222,17 +209,16 @@ class PDF(FPDF):
         qr_img = self.generate_qr_code()
         self.image(qr_img, w=30, x=Align.R, y=5)
         self.set_font(self.font, size=PDF.FONT_SIZES['h4'])
-        if url and self.parent_url != url:
-            self.cell(
-                text='Component URL:',
-                align='L'
-            )
-            self.cell(
-                text=f'{url}',
-                align='L',
-                link=url
-            )
-            self.write(0, '\n\n')
+        self.cell(
+            text='Project URL:',
+            align='L'
+        )
+        self.cell(
+            text=f'{url}',
+            align='L',
+            link=url
+        )
+        self.write(0, '\n\n')
         self.ln()
         self.ln()
 
@@ -357,10 +343,7 @@ def explore_project_tree(project, projects, pdf=None):
 
     # Start with no PDF at root projects
     if not pdf:
-        pdf = PDF(
-            parent_title=project['metadata']['title'],
-            parent_url=project['metadata']['url']
-        )
+        pdf = PDF()
 
     # Add current project to PDF
     pdf._write_project_body(project)

--- a/src/osfexport/stubs/asingle.json
+++ b/src/osfexport/stubs/asingle.json
@@ -311,9 +311,9 @@
             }
         },
         "links": {
-            "html": "https://test.osf.io/x/",
-            "self": "https://api.test.osf.io/v2/nodes/x/",
-            "iri": "https://test.osf.io/x"
+            "html": "https://test.osf.io/a/",
+            "self": "https://api.test.osf.io/v2/nodes/a/",
+            "iri": "https://test.osf.io/a"
         }
     },
     "links": {

--- a/src/osfexport/stubs/components/x-child-1.json
+++ b/src/osfexport/stubs/components/x-child-1.json
@@ -312,8 +312,8 @@
                 }
             },
             "links": {
-                "html": "https://test.osf.io/x/",
-                "self": "https://api.test.osf.io/v2/nodes/x/",
+                "html": "https://test.osf.io/a/",
+                "self": "https://api.test.osf.io/v2/nodes/a/",
                 "iri": "https://test.osf.io/x"
             }
         }

--- a/src/osfexport/stubs/components/x-child-2.json
+++ b/src/osfexport/stubs/components/x-child-2.json
@@ -312,9 +312,9 @@
                 }
             },
             "links": {
-                "html": "https://test.osf.io/x/",
-                "self": "https://api.test.osf.io/v2/nodes/x/",
-                "iri": "https://test.osf.io/x"
+                "html": "https://test.osf.io/b/",
+                "self": "https://api.test.osf.io/v2/nodes/b/",
+                "iri": "https://test.osf.io/b"
             }
         }
     ],

--- a/src/osfexport/stubs/nodestubs.json
+++ b/src/osfexport/stubs/nodestubs.json
@@ -318,7 +318,7 @@
             "links": {
                 "html": "https://test.osf.io/x/",
                 "self": "https://api.test.osf.io/v2/nodes/x/",
-                "iri": "https://test.osf.io/x"
+                "iri": "https://test.osf.io/x/"
             }
         },
         {
@@ -625,8 +625,8 @@
             },
             "links": {
                 "html": "https://test.osf.io/y/",
-                "self": "https://api.test.osf.io/v2/nodes/x/",
-                "iri": "https://test.osf.io/x"
+                "self": "https://api.test.osf.io/v2/nodes/y/",
+                "iri": "https://test.osf.io/y"
             }
         },
         {
@@ -942,8 +942,8 @@
             },
             "links": {
                 "html": "https://test.osf.io/a/",
-                "self": "https://api.test.osf.io/v2/nodes/x/",
-                "iri": "https://test.osf.io/x"
+                "self": "https://api.test.osf.io/v2/nodes/a/",
+                "iri": "https://test.osf.io/a"
             }
         },
         {
@@ -1259,8 +1259,8 @@
             },
             "links": {
                 "html": "https://test.osf.io/b/",
-                "self": "https://api.test.osf.io/v2/nodes/x/",
-                "iri": "https://test.osf.io/x"
+                "self": "https://api.test.osf.io/v2/nodes/b/",
+                "iri": "https://test.osf.io/b"
             }
         },
         {

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -690,7 +690,7 @@ class TestFormatter(TestCase):
                     ('file2.txt', None, None),
                 ],
                 'wikis': {},
-                "parent": 'id',
+                "parent": ('My Project Title', 'https://test.osf.io/x'),
                 'children': ['b']
             },
             {
@@ -743,7 +743,7 @@ class TestFormatter(TestCase):
                     ('file2.txt', None, None),
                 ],
                 'wikis': {},
-                "parent": 'a',
+                "parent": ('child1', 'https://test.osf.io/a'),
                 'children': []
             },
         ]
@@ -799,9 +799,17 @@ class TestFormatter(TestCase):
         content_first_page = import_one.pages[0].extract_text(
             extraction_mode='layout'
         )
+        assert f'{projects[0]['metadata']['title']}' in content_first_page, (
+            content_first_page
+        )
+
         content_second_page = import_two.pages[0].extract_text(
             extraction_mode='layout'
         )
+        assert 'Category: Methods and Measures' in content_second_page, (
+            content_second_page
+        )
+
         content_third_page = import_one.pages[3].extract_text(
             extraction_mode='layout'
         )
@@ -819,9 +827,6 @@ class TestFormatter(TestCase):
         )
         assert 'Category: Uncategorized' in content_first_page, (
             content_first_page
-        )
-        assert 'Category: Methods and Measures' in content_second_page, (
-            content_second_page
         )
         timestamp = pdf_one.date_printed.strftime(
             '%Y-%m-%d %H:%M:%S %Z')
@@ -875,6 +880,18 @@ class TestFormatter(TestCase):
             'Actual: ',
             content_first_page.replace(' ', '')
         )
+
+        #print(import_one.pages[4].extract_text(extraction_mode='layout'))
+
+        content_fourth_page = import_one.pages[4].extract_text(
+            extraction_mode='layout'
+        )
+        assert f'{projects[0]['metadata']['title']}' not in content_fourth_page, (
+            'Incorrect parent title for component'
+        )
+        assert f'{projects[2]['metadata']['title']}' in content_fourth_page
+        assert f'Parent: {projects[2]['parent'][0]}' in content_fourth_page
+        assert f'Parent URL: {projects[2]['parent'][1]}' in content_fourth_page
 
         # Remove files only if all good - keep for debugging otherwise
         if os.path.exists(FOLDER_OUT):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -586,7 +586,7 @@ class TestFormatter(TestCase):
                     'Home': 'hello world',
                     'Page2': 'another page'
                 },
-                "parent": 'https://test.osf.io/parent-id',
+                "parent": ('apple', 'https://test.osf.io/parent-id'),
                 'children': ['a']
             }
         ]
@@ -605,7 +605,8 @@ class TestFormatter(TestCase):
 
             page_one = PdfReader(path_one)
             text = page_one.pages[0].extract_text()
-            assert 'Component of: https://test.osf.io/parent-id' in text, (
+            assert f'Parent: {projects[0]['parent'][0]}' in text
+            assert f'Parent URL: {projects[0]['parent'][1]}' in text, (
                 'Expected parent URL in PDF, got: ',
                 text
             )
@@ -889,9 +890,11 @@ class TestFormatter(TestCase):
         assert f'{projects[0]['metadata']['title']}' not in content_fourth_page, (
             'Incorrect parent title for component'
         )
-        assert f'{projects[2]['metadata']['title']}' in content_fourth_page
-        assert f'Parent: {projects[2]['parent'][0]}' in content_fourth_page
-        assert f'Parent URL: {projects[2]['parent'][1]}' in content_fourth_page
+        assert f'{projects[3]['metadata']['title']}' in content_fourth_page
+        assert f'Parent: {projects[3]['parent'][0]}' in content_fourth_page
+        assert f'Parent URL:   {projects[3]['parent'][1]}' in content_fourth_page, (
+            projects[3]['parent'][1], content_fourth_page
+        )
 
         # Remove files only if all good - keep for debugging otherwise
         if os.path.exists(FOLDER_OUT):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -369,14 +369,12 @@ class TestExporter(TestCase):
         )
 
         assert projects[3]['parent'][0] == projects[2]['metadata']['title'], (
-            projects[3]['parent'],
-            'Expected: ', projects[2]['metadata']['title']
+            projects[3]['parent'][0],
+            f'Expected: {projects[2]['metadata']['title']}'
         )
-
-        # For mock tests, the URL of the parent is the same as the parent GUID
-        assert projects[3]['parent'][1] == projects[2]['metadata']['id'], (
+        assert projects[3]['parent'][1] == projects[2]['metadata']['url'], (
             projects[3]['parent'][1],
-            f'Expected: {projects[2]['metadata']['id']}'
+            f'Expected: {projects[2]['metadata']['url']}'
         )
 
     def test_get_paginated_projects(self):
@@ -483,8 +481,13 @@ class TestExporter(TestCase):
             projects
         )
         assert projects[0]['metadata']['id'] == 'a'
-        assert projects[0]['parent'] == ['Test1', 'x'], (
-            projects[0]['parent']
+        assert projects[0]['parent'][0] == 'Test1', (
+            projects[0]['parent'][0],
+            f'Expected: Test1'
+        )
+        assert projects[0]['parent'][1] == 'https://test.osf.io/x/', (
+            projects[0]['parent'][1],
+            'Expected: https://test.osf.io/x/'
         )
 
 

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -493,7 +493,7 @@ class TestExporter(TestCase):
         assert projects[0]['metadata']['id'] == 'a'
         assert projects[0]['parent'][0] == 'Test1', (
             projects[0]['parent'][0],
-            f'Expected: Test1'
+            'Expected: Test1'
         )
         assert projects[0]['parent'][1] == 'https://test.osf.io/x/', (
             projects[0]['parent'][1],
@@ -905,8 +905,6 @@ class TestFormatter(TestCase):
             'Actual: ',
             content_first_page.replace(' ', '')
         )
-
-        #print(import_one.pages[4].extract_text(extraction_mode='layout'))
 
         content_fourth_page = import_one.pages[4].extract_text(
             extraction_mode='layout'

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -368,6 +368,17 @@ class TestExporter(TestCase):
             projects[1]['metadata']['category']
         )
 
+        assert projects[3]['parent'][0] == projects[2]['metadata']['title'], (
+            projects[3]['parent'],
+            'Expected: ', projects[2]['metadata']['title']
+        )
+
+        # For mock tests, the URL of the parent is the same as the parent GUID
+        assert projects[3]['parent'][1] == projects[2]['metadata']['id'], (
+            projects[3]['parent'][1],
+            f'Expected: {projects[2]['metadata']['id']}'
+        )
+
     def test_get_paginated_projects(self):
         projects, root_nodes = get_nodes(
             pat='',
@@ -472,7 +483,7 @@ class TestExporter(TestCase):
             projects
         )
         assert projects[0]['metadata']['id'] == 'a'
-        assert projects[0]['parent'] == 'x', (
+        assert projects[0]['parent'] == ['Test1', 'x'], (
             projects[0]['parent']
         )
 
@@ -586,7 +597,7 @@ class TestFormatter(TestCase):
                     'Home': 'hello world',
                     'Page2': 'another page'
                 },
-                "parent": ('apple', 'https://test.osf.io/parent-id'),
+                "parent": ['apple', 'https://test.osf.io/parent-id'],
                 'children': ['a']
             }
         ]
@@ -744,7 +755,7 @@ class TestFormatter(TestCase):
                     ('file2.txt', None, None),
                 ],
                 'wikis': {},
-                "parent": ('child1', 'https://test.osf.io/a'),
+                "parent": ['child1', 'https://test.osf.io/a'],
                 'children': []
             },
         ]


### PR DESCRIPTION
Closes #86.

Instead of saying the first project in a export PDF is the parent of all components in the PDF, we now explicitly say what the direct parent of a component is.

If we can't access the parent (e.g. choose to export a public component, with a private parent, and don't give a PAT) then the parent will not be included in the title section for the component.