### PR TITLE
49 improve error handling and input validation

### DIFF
--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -98,8 +98,11 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
     except HTTPError as e:
         if e.code == 401:
             click.echo(
-                """The PAT given does not have permission to export the chosen projects.
-            Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor on this project if it's private."""
+                """The PAT given does not have permission to export the chosen projects. Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor on this project if it's private."""
+            )
+        elif e.code == 404:
+            click.echo(
+                """The project could not be found. Please check the URL or project ID given is correct."""
             )
 
 

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -109,6 +109,10 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             click.echo(
                 f"""You aren't able to access {"these projects" if not project_id else "this project"}. Please double-check you have assigned the "osf.full_read" permission to your token{", and you are a contributor if it's private" if project_id else ""}."""
             )
+        else:
+            click.echo(
+                f"Unexpected error: {e.code}. Please try again later."
+            )
 
 
 @click.command()

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -96,9 +96,10 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             pdf, path = formatter.write_pdf(projects, idx, folder)
             click.echo(f'Project exported to {path}')
     except HTTPError as e:
+        click.echo("Exporting failed as an error occurred:\n")
         if e.code == 401:
             click.echo(
-                f"""The PAT given does not have permission to export the chosen project{"s" if not project_id else ""}. Please double-check you have assigned the "osf.full_read" permission to your token{", and you are a contributor if it's private" if project_id else ""}."""
+                f"""The PAT used could not be used to authenticate you. Did you enter your PAT correctly?"""
             )
         elif e.code == 404:
             click.echo(
@@ -106,7 +107,7 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             )
         elif e.code == 403:
             click.echo(
-                """You aren't able to access this. Check that you are a contributor."""
+                f"""You aren't able to access {"these projects" if not project_id else "this project"}. Please double-check you have assigned the "osf.full_read" permission to your token{", and you are a contributor if it's private" if project_id else ""}."""
             )
 
 

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -98,11 +98,15 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
     except HTTPError as e:
         if e.code == 401:
             click.echo(
-                """The PAT given does not have permission to export the chosen projects. Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor on this project if it's private."""
+                f"""The PAT given does not have permission to export the chosen project{"s" if not project_id else ""}. Please double-check you have assigned the "osf.full_read" permission to your token{", and you are a contributor if it's private" if project_id else ""}."""
             )
         elif e.code == 404:
             click.echo(
                 """The project could not be found. Please check the URL or project ID given is correct."""
+            )
+        elif e.code == 403:
+            click.echo(
+                """You aren't able to access this. Check that you are a contributor."""
             )
 
 

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -273,12 +273,12 @@ def paginate_json_result(start, action, **kwargs):
                 curr_page = MockAPIResponse.read(next_link)
             results.append(action(curr_page, **kwargs))
         except HTTPError as e:
-            pass
+            print("Error whilst parsing JSON page; skipping to next one...")
         # Stop if no next link found
         try:
             next_link = curr_page['links']['next']
             is_last_page = not next_link
-        except KeyError:
+        except (KeyError, UnboundLocalError):
             is_last_page = True
     return results
 
@@ -461,12 +461,12 @@ def get_nodes(pat, page_size=100, dryrun=False, project_id='', usetest=False):
             start = project_id
         else:
             start = 'nodes'
-
+    
     results = paginate_json_result(
         start, get_project_data, dryrun=dryrun, usetest=usetest,
         pat=pat, filters=node_filter, project_id=project_id, per_page=page_size
     )
-    l1, l2 = zip(*list(results))
+    l1, l2 = zip(*list(results)) if len(results) > 0 else (), ()
     projects = [item for sublist in l1 for item in sublist]
 
     # After pagination we get indexes of root nodes local to each page

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -466,7 +466,10 @@ def get_nodes(pat, page_size=100, dryrun=False, project_id='', usetest=False):
         start, get_project_data, dryrun=dryrun, usetest=usetest,
         pat=pat, filters=node_filter, project_id=project_id, per_page=page_size
     )
-    l1, l2 = zip(*list(results)) if len(results) > 0 else (), ()
+    if len(results) > 0:
+        l1, l2 = zip(*list(results))
+    else:
+        l1, l2 = (), ()
     projects = [item for sublist in l1 for item in sublist]
 
     # After pagination we get indexes of root nodes local to each page

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -111,7 +111,7 @@ class MockAPIResponse:
             with open(MockAPIResponse.MARKDOWN_FILES[field], 'r') as file:
                 return file.read()
         else:
-            return {}
+            return {'data': {}}
 
 
 def extract_project_id(url):

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -671,7 +671,7 @@ def get_project_data(nodes, **kwargs):
                 click.echo(f"A project failed to export: {e.code}")
             else:
                 click.echo(f"A project failed to export: Unexpected API response.")
-            click.echo("COntinuing with exporting other projects...")
+            click.echo("Continuing with exporting other projects...")
 
     return projects, root_nodes
 

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -1010,25 +1010,7 @@ class TestCLI(TestCase):
             ],
             terminal_width=60
         )
-        message = """The PAT given does not have permission to export the chosen projects. Please double-check you have assigned the "osf.full_read" permission to your token."""
-        assert message in result.output, (
-                result.output,
-                message
-            )
-        
-        result = runner.invoke(
-            cli, [
-                'export-projects',
-                '--usetest',
-                '--url', 'abc'
-            ],
-            terminal_width=60
-        )
-        message = """The PAT given does not have permission to export the chosen project. Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor if it's private."""
-        assert message in result.output, (
-                result.output,
-                message
-            )
+        assert "Exporting failed as an error occurred:" in result.output
 
     def test_pull_projects_command_on_mocks(self):
         """Test generating a PDF from parsed project data.

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -1010,9 +1010,24 @@ class TestCLI(TestCase):
             ],
             terminal_width=60
         )
-        assert """The PAT given does not have permission to export the chosen projects.
-            Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor on this project if it's private.""" in result.output, (
-                result.output
+        message = """The PAT given does not have permission to export the chosen projects. Please double-check you have assigned the "osf.full_read" permission to your token."""
+        assert message in result.output, (
+                result.output,
+                message
+            )
+        
+        result = runner.invoke(
+            cli, [
+                'export-projects',
+                '--usetest',
+                '--url', 'abc'
+            ],
+            terminal_width=60
+        )
+        message = """The PAT given does not have permission to export the chosen project. Please double-check you have assigned the "osf.full_read" permission to your token, and you are a contributor if it's private."""
+        assert message in result.output, (
+                result.output,
+                message
             )
 
     def test_pull_projects_command_on_mocks(self):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -184,13 +184,20 @@ class TestExporter(TestCase):
         )
         results = paginate_json_result(
             start='nodes', action=mock_get_data, dryrun=True, usetest=False,
-            pat='', filters={}, project_id='', per_page=20
+            pat='', filters={}, project_id='', per_page=20, fail_on_first=False
         )
         # There are 2 pages of nodes to read in the mock JSON data
         assert mock_get_data.call_count == 2, (
             f'Wrong num of calls: {mock_get_data.call_count}'
         )
         assert results is not None
+
+        # Raise error on first error
+        with self.assertRaises(urllib.error.HTTPError):
+            results = paginate_json_result(
+                start='nodes', action=mock_get_data, dryrun=True, usetest=False,
+                pat='', filters={}, project_id='', per_page=20
+            )
 
     @patch('urllib.request.urlopen')
     @patch('urllib.request.Request')

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -994,23 +994,25 @@ class TestCLI(TestCase):
     @patch('osfexport.cli.prompt_pat')
     @patch('osfexport.exporter.get_nodes')
     def test_export_projects_handles_http_errors(self, mock_func, mock_prompt):
-        mock_prompt.return_value = '-'
-        mock_func.side_effect = urllib.error.HTTPError(
-            url='https://test.osf.io',
-            code=401,
-            msg='HTTP Error 401: Unauthorized',
-            hdrs={},
-            fp=None
-        )
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, [
-                'export-projects',
-                '--usetest'
-            ],
-            terminal_width=60
-        )
-        assert "Exporting failed as an error occurred:" in result.output
+        codes = [401, 402, 403, 404, 500]
+        for code in codes:
+            mock_prompt.return_value = '-'
+            mock_func.side_effect = urllib.error.HTTPError(
+                url='https://test.osf.io',
+                code=code,
+                msg='HTTP Error',
+                hdrs={},
+                fp=None
+            )
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, [
+                    'export-projects',
+                    '--usetest'
+                ],
+                terminal_width=60
+            )
+            assert "Exporting failed as an error occurred:" in result.output
 
     def test_pull_projects_command_on_mocks(self):
         """Test generating a PDF from parsed project data.


### PR DESCRIPTION
Closes #49 with general error handling improvements:

- more useful error messages with suggestions on what a user can do (e.g. check PAT is correct, has right permissions)
- if exporting one project in a batch fails, move on to the next one
- If reading a response page fails partway through, move on to the next one or raise an error if on the first page
- prevent errors from certain flag combos e.g. --url and --dryrun