### PR TITLE
74 handle 429 errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
     - name: Run local tests
       run: |
           python -m unittest tests.test_clitool.TestExporter
+          python -m unittest tests.test_clitool.TestFormatter
           python -m unittest tests.test_clitool.TestCLI
     - name: Run API tests
       run: |

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -125,7 +125,7 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
                 )
         else:
             click.echo(
-                f"Unexpected error: {e.reason}. Please try again later."
+                f"Unexpected error connecting to the OSF: {e.reason}. Please try again later."
             )
 
 

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -100,16 +100,17 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
         if isinstance(e, HTTPError):
             if e.code == 401:
                 click.echo(
-                    "The PAT used could not authenticate you. Did you enter your PAT correctly?"
+                    "The token used couldn't authenticate you. You may have entered it incorrectly."
                 )
                 click.echo()
             elif e.code == 404:
                 click.echo(
-                    """The project couldn't be found. Please check the URL or project ID is correct."""
+                    """The project couldn't be found. Please check the URL/project ID is correct."""
                 )
             elif e.code == 403:
+                text = "this project" if project_id else "these projects"
                 click.echo(
-                    f"You aren't able to access {"this project" if project_id else "these projects"}."
+                    f"You aren't a contributor for {text}."
                 )
                 click.echo(
                     f"""Please check your PAT has the \"osf.full_read\" permission
@@ -117,7 +118,7 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
                 )
             elif e.code == 429:
                 click.echo(
-                    f"""Too many requests to the API, please try again in a few minutes."""
+                    """Too many requests to the API, please try again in a few minutes."""
                 )
             else:
                 click.echo(
@@ -127,7 +128,6 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             click.echo(
                 f"Unexpected error connecting to the OSF: {e.reason}. Please try again later."
             )
-
 
 
 @click.command()

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -96,26 +96,34 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             pdf, path = formatter.write_pdf(projects, idx, folder)
             click.echo(f'Project exported to {path}')
     except (HTTPError, URLError) as e:
-        click.echo("Exporting failed as an error occurred:\n")
+        click.echo("Exporting failed as an error occurred: ")
         if isinstance(e, HTTPError):
             if e.code == 401:
                 click.echo(
-                    "The token used couldn't authenticate you. You may have entered it incorrectly."
+                    "We couldn't authenticate you with the personal access token."
                 )
-                click.echo()
+                click.echo(
+                    "If you already have access to the OSF, please check the token is correct."
+                )
             elif e.code == 404:
                 click.echo(
-                    """The project couldn't be found. Please check the URL/project ID is correct."""
+                    "The project couldn't be found. Please check the URL/project ID is correct."
                 )
             elif e.code == 403:
-                text = "this project" if project_id else "these projects"
-                click.echo(
-                    f"You aren't a contributor for {text}."
-                )
-                click.echo(
-                    f"""Please check your PAT has the \"osf.full_read\" permission
-                    {", and you are a contributor if it's private" if project_id else ""}."""
-                )
+                if project_id:
+                    click.echo(
+                        "Please check you are a contributor for this private project."
+                    )
+                    click.echo(
+                        "If you are, does your personal access token have the \"osf.full_read\" permission?"
+                    )
+                else:
+                    click.echo(
+                        "Does your personal access token have the \"osf.full_read\" permission?"
+                    )
+                    click.echo(
+                        "This is needed to allow access to your projects with this token."
+                    )
             elif e.code == 429:
                 click.echo(
                     """Too many requests to the API, please try again in a few minutes."""

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -115,7 +115,7 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
                         "Please check you are a contributor for this private project."
                     )
                     click.echo(
-                        "If you are, does your personal access token have the \"osf.full_read\" permission?"
+                        "If you are, does your token have the \"osf.full_read\" permission?"
                     )
                 else:
                     click.echo(

--- a/src/osfexport/cli.py
+++ b/src/osfexport/cli.py
@@ -1,5 +1,5 @@
 import os
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import click
 
@@ -95,29 +95,39 @@ def export_projects(folder, pat='', dryrun=False, url='', usetest=False):
             click.echo(f'Exporting project {title}...')
             pdf, path = formatter.write_pdf(projects, idx, folder)
             click.echo(f'Project exported to {path}')
-    except HTTPError as e:
+    except (HTTPError, URLError) as e:
         click.echo("Exporting failed as an error occurred:\n")
-        if e.code == 401:
-            click.echo(
-                "The PAT used could not authenticate you. Did you enter your PAT correctly?"
-            )
-            click.echo()
-        elif e.code == 404:
-            click.echo(
-                """The project couldn't be found. Please check the URL or project ID is correct."""
-            )
-        elif e.code == 403:
-            click.echo(
-                f"You aren't able to access {"this project" if project_id else "these projects"}."
-            )
-            click.echo(
-                f"""Please check your PAT has the \"osf.full_read\" permission
-                {", and you are a contributor if it's private" if project_id else ""}."""
-            )
+        if isinstance(e, HTTPError):
+            if e.code == 401:
+                click.echo(
+                    "The PAT used could not authenticate you. Did you enter your PAT correctly?"
+                )
+                click.echo()
+            elif e.code == 404:
+                click.echo(
+                    """The project couldn't be found. Please check the URL or project ID is correct."""
+                )
+            elif e.code == 403:
+                click.echo(
+                    f"You aren't able to access {"this project" if project_id else "these projects"}."
+                )
+                click.echo(
+                    f"""Please check your PAT has the \"osf.full_read\" permission
+                    {", and you are a contributor if it's private" if project_id else ""}."""
+                )
+            elif e.code == 429:
+                click.echo(
+                    f"""Too many requests to the API, please try again in a few minutes."""
+                )
+            else:
+                click.echo(
+                    f"Unexpected error: HTTP {e.code}. Please try again later."
+                )
         else:
             click.echo(
-                f"Unexpected error: {e.code}. Please try again later."
+                f"Unexpected error: {e.reason}. Please try again later."
             )
+
 
 
 @click.command()

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -316,7 +316,7 @@ def paginate_json_result(start, action, fail_on_first=True, **kwargs):
                 curr_page = MockAPIResponse.read(next_link)
             results.append(action(curr_page, **kwargs))
         except HTTPError as e:
-            if fail_on_first and is_first_item:
+            if fail_on_first and is_first_item or e.code == 429:
                 raise e
             else:
                 click.echo("Error whilst parsing JSON page; continuing with other pages...")
@@ -708,6 +708,8 @@ def get_project_data(nodes, **kwargs):
             projects.append(project_data)
         except (HTTPError, KeyError) as e:
             if isinstance(e, HTTPError):
+                if e.code == 429:
+                    raise e
                 click.echo(f"A project failed to export: {e.code}")
             else:
                 click.echo("A project failed to export: Unexpected API response.")

--- a/src/osfexport/exporter.py
+++ b/src/osfexport/exporter.py
@@ -173,8 +173,7 @@ def is_public(url):
 
 def call_api(
         url, pat, method='GET', per_page=100, filters={}, is_json=True,
-        usetest=False, max_tries=5
-    ):
+        usetest=False, max_tries=5):
     """Call OSF v2 API methods.
 
     Parameters
@@ -201,7 +200,7 @@ def call_api(
         This spaces out requests over time to give the API chance to recover.
     max_tries: int
         Number of attempts to make before raising a 429 error. Default is 5, Limit is 7.
-    
+
     Throws
     -------------
         HTTPError - 429 error if we can't connect to the API after retries.
@@ -232,10 +231,10 @@ def call_api(
             'Accept',
             f'application/vnd.api+json;version={API_VERSION}'
         )
-    
+
     if max_tries > 7:
-        max_tries = 7  #  Cap retries to reduce requests sent and max delay time
-    
+        max_tries = 7  # Cap retries to reduce requests sent and max delay time
+
     # Retry requests if we get 429 errors
     try_count = 0
     result = None

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -214,7 +214,7 @@ class TestExporter(TestCase):
                 start='nodes', action=mock_get_data, dryrun=True, usetest=False,
                 pat='', filters={}, project_id='', per_page=20
             )
-        
+
         # Raise error if it's HTTP 429 error code
         mock_get_data.side_effect = urllib.error.HTTPError(
             url='https://test.osf.io',
@@ -244,7 +244,7 @@ class TestExporter(TestCase):
             call().add_header('Accept', 'application/vnd.api+json;version=2.20')
         ]
         mock_request_class.assert_has_calls(expected_calls, any_order=False)
-    
+
     @patch('urllib.request.urlopen')
     @patch('urllib.request.Request')
     def test_call_api_handle_429_errors(self, mock_request_class, mock_urlopen):
@@ -264,7 +264,6 @@ class TestExporter(TestCase):
             # Use constant time delays instead of random for quick test
             call_api('https://test.osf.io', pat='pat', is_json=True, usetest=True)
         assert len(mock_urlopen.call_args_list) == 5
-        
 
     def test_get_public_status(self):
         # Public url

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -230,11 +230,10 @@ class TestExporter(TestCase):
             fp=None
         )
 
-        max_tries = 5
         with self.assertRaises(urllib.error.HTTPError):
             # Use constant time delays instead of random for quick test
-            call_api('https://test.osf.io', pat='pat', is_json=True, max_tries=max_tries, usetest=True)
-        assert len(mock_urlopen.call_args_list) == max_tries
+            call_api('https://test.osf.io', pat='pat', is_json=True, usetest=True)
+        assert len(mock_urlopen.call_args_list) == 5
         
 
     def test_get_public_status(self):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -509,7 +509,7 @@ class TestExporter(TestCase):
             roots
         )
         assert len(projects) == 3, (
-            print(projects)
+            projects
         )
         assert projects[0]['metadata']['id'] == 'x'
         assert projects[0]['children'] == ['a', 'b'], (
@@ -659,7 +659,6 @@ class TestFormatter(TestCase):
         except Exception as e:
             if isinstance(e, AssertionError):
                 raise e
-            print(e)
         finally:
             if os.path.exists(path_one):
                 os.remove(path_one)
@@ -733,7 +732,6 @@ class TestFormatter(TestCase):
         except Exception as e:
             if isinstance(e, AssertionError):
                 raise e
-            print(e)
         finally:
             if os.path.exists(path_one):
                 os.remove(path_one)
@@ -1067,7 +1065,6 @@ class TestCLI(TestCase):
                 ],
                 terminal_width=60
             )
-            print(result.output)
             assert "Exporting failed as an error occurred:" in result.output
 
     def test_pull_projects_command_on_mocks(self):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -994,7 +994,7 @@ class TestCLI(TestCase):
     @patch('osfexport.cli.prompt_pat')
     @patch('osfexport.exporter.get_nodes')
     def test_export_projects_handles_http_url_errors(self, mock_func, mock_prompt):
-        codes = [401, 402, 403, 404, 500, -1]
+        codes = [401, 402, 403, 404, 429, 500, -1]
         for code in codes:
             mock_prompt.return_value = '-'
             if code != -1:

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -993,17 +993,22 @@ class TestCLI(TestCase):
 
     @patch('osfexport.cli.prompt_pat')
     @patch('osfexport.exporter.get_nodes')
-    def test_export_projects_handles_http_errors(self, mock_func, mock_prompt):
-        codes = [401, 402, 403, 404, 500]
+    def test_export_projects_handles_http_url_errors(self, mock_func, mock_prompt):
+        codes = [401, 402, 403, 404, 500, -1]
         for code in codes:
             mock_prompt.return_value = '-'
-            mock_func.side_effect = urllib.error.HTTPError(
-                url='https://test.osf.io',
-                code=code,
-                msg='HTTP Error',
-                hdrs={},
-                fp=None
-            )
+            if code != -1:
+                mock_func.side_effect = urllib.error.HTTPError(
+                    url='https://test.osf.io',
+                    code=code,
+                    msg='HTTP Error',
+                    hdrs={},
+                    fp=None
+                )
+            else:
+                mock_func.side_effect = urllib.error.URLError(
+                    reason="URL Error"
+                )
             runner = CliRunner()
             result = runner.invoke(
                 cli, [

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -32,14 +32,10 @@ from osfexport.formatter import (
     HTMLImageSizeCapRenderer,
     write_pdf
 )
-# from mistletoe import markdown
 
 TEST_PDF_FOLDER = 'good-pdfs'
 TEST_INPUT = 'test_pdf.pdf'
 FOLDER_OUT = os.path.join('tests', 'outfolder')
-
-# Run tests in docker container
-# with 'python -m unittest <tests.test_clitool.TESTCLASS>'
 
 
 class TestAPI(TestCase):
@@ -1071,6 +1067,7 @@ class TestCLI(TestCase):
                 ],
                 terminal_width=60
             )
+            print(result.output)
             assert "Exporting failed as an error occurred:" in result.output
 
     def test_pull_projects_command_on_mocks(self):

--- a/tests/test_clitool.py
+++ b/tests/test_clitool.py
@@ -230,9 +230,10 @@ class TestExporter(TestCase):
             fp=None
         )
 
-        max_tries = 3
+        max_tries = 5
         with self.assertRaises(urllib.error.HTTPError):
-            call_api('https://test.osf.io', pat='pat', is_json=True, wait_time=0.1, max_tries=max_tries)
+            # Use constant time delays instead of random for quick test
+            call_api('https://test.osf.io', pat='pat', is_json=True, max_tries=max_tries, usetest=True)
         assert len(mock_urlopen.call_args_list) == max_tries
         
 


### PR DESCRIPTION
Closes #74 by adding exponential backoff, jittering and a cut-off for retries of requests in `call_api` if it encounters a 429 error initially. After a number of attempts the request will fail and the CLI user will see an error message saying to come back later.